### PR TITLE
fix(trailingSlash): ignore routes when ending with file extension

### DIFF
--- a/src/extractLinks.ts
+++ b/src/extractLinks.ts
@@ -52,7 +52,7 @@ export function extractLinks(
       pathname: url.pathname || '/',
       url,
       badAbsolute: Boolean(hostname) && hostname === url.host,
-      badTrailingSlash: url.pathname !== '/' && ((trailingSlash && !url.pathname.endsWith('/')) || (!trailingSlash && url.pathname.endsWith('/'))),
+      badTrailingSlash: url.pathname !== '/' && !url.pathname.split('/').at(-1).includes('.') && ((trailingSlash && !url.pathname.endsWith('/')) || (!trailingSlash && url.pathname.endsWith('/'))),
       element: $.html(el) || '',
     })
   })


### PR DESCRIPTION
### Description

This PR will ignore routes for trailing slash check which end with `.XYZ`, e.g. `.json`.

### Linked Issues

Fixes #6 