### PR TITLE
chore: loosen nuxt kit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "pnpm lint"
   },
   "dependencies": {
-    "@nuxt/kit": "3.4.1",
+    "@nuxt/kit": "^3.4.1",
     "chalk": "^5.2.0",
     "cheerio": "1.0.0-rc.12",
     "radix3": "^1.0.1",


### PR DESCRIPTION

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixing the nuxt/kit version sometimes leads to typescript errors due to a difference in the types in two versions of nuxt/kit.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
