### PR TITLE
fix(view): add missing import

### DIFF
--- a/src/runtime/plugin/view/Main.vue
+++ b/src/runtime/plugin/view/Main.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { NuxtLinkCheckerClient } from '../../types'
 import Squiggle from './Squiggle.vue'
 import { useEventListener } from './utils'


### PR DESCRIPTION
### Description

`computed` is used in the script and has to be imported from `vue`.

### Linked Issues

n/a 

### Additional context

n/a
