### PR TITLE
fix(inspect): add missing import

### DIFF
--- a/src/runtime/server/api/inspect.ts
+++ b/src/runtime/server/api/inspect.ts
@@ -5,7 +5,7 @@ import { inspect } from '../../inspect'
 import type { RuleTestContext } from '../../types'
 import { generateFileLinkDiff, generateFileLinkPreviews } from '../util'
 import { getLinkResponse } from '../../crawl'
-import { useNitroApp, useRuntimeConfig, useSiteConfig } from '#imports'
+import { useNitroApp, useNitroOrigin, useRuntimeConfig, useSiteConfig } from '#imports'
 
 // verify a link
 export default defineEventHandler(async (e) => {


### PR DESCRIPTION
### Description

Adds a missing import for  `useNitroOrigin`.

### Linked Issues

n/a

### Additional context

n/a
