### PR TITLE
docs: remove `nuxt.config` section in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,10 @@ Find and magically fix links that may be negatively effecting your Nuxt sites SE
 
 ## Installation
 
-1. Install `nuxt-link-checker` dependency to your project:
+Install `nuxt-link-checker` dependency to your project:
 
 ```bash
 npx nuxi@latest module add link-checker
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['nuxt-link-checker']
-})
 ```
 
 # Documentation


### PR DESCRIPTION
### Description

`nuxi module add` section has been added for Nuxt OG Image in #29  issue.

nuxt.config is automatically added by Nuxi, so I removed (2).

### Linked Issues

related #29 .

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
