### PR TITLE
fix: accept #top links as they're valid according to the HTML standard

### DIFF
--- a/src/runtime/pure/inspections/missing-hash.ts
+++ b/src/runtime/pure/inspections/missing-hash.ts
@@ -7,7 +7,7 @@ export default function RuleMissingHash() {
   return defineRule({
     test({ link, report, ids, fromPath }) {
       const [path, hash] = link.split('#')
-      if (!link.includes('#') || fixSlashes(false, path) !== fromPath)
+      if (!link.includes('#') || link.endsWith('#top') || fixSlashes(false, path) !== fromPath)
         return
 
       if (ids.includes(hash))

--- a/test/unit/rules/missing-hash.test.ts
+++ b/test/unit/rules/missing-hash.test.ts
@@ -34,4 +34,22 @@ describe('rule missing-hash', () => {
       }
     `)
   })
+  it('works with #top', () => {
+    const ctx = {
+      link: '/about#top',
+      ids: [],
+      fromPath: '/about',
+    } as RuleTestContext
+
+    expect(runRule(ctx, RuleMissingHash())).toMatchInlineSnapshot(`
+      {
+        "error": [],
+        "fix": "/about#top",
+        "link": "/about#top",
+        "passes": true,
+        "textContent": undefined,
+        "warning": [],
+      }
+    `)
+  })
 })


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`#top` links are valid according to the [HTML spec](https://html.spec.whatwg.org/multipage/browsing-the-web.html#top-of-the-document) but the link checker reports them as *wrong*. This PR should fix that.

![image](https://github.com/harlan-zw/nuxt-link-checker/assets/7005614/0fb821a5-2fc0-4507-be43-3b94c32377c6)

### Linked Issues

### Additional context

It's my first PR here so I went for the simplest approach to *get the ball rolling*.