### PR TITLE
fix: ignore fragment-only links

### DIFF
--- a/src/runtime/shared/inspections/trailing-slash.ts
+++ b/src/runtime/shared/inspections/trailing-slash.ts
@@ -7,6 +7,12 @@ export default function RuleTrailingSlash() {
     id: 'trailing-slash',
     test({ report, link, siteConfig }) {
       const $url = parseURL(link)
+
+      // Ignore fragment-only links
+      if($url.pathname.startsWith('#') {
+        return
+      }
+      
       // its a file when the last segment has a dot in it
       const isFile = $url.pathname.split('/').pop()!.includes('.')
       if ($url.pathname === '/' || isFile)

--- a/src/runtime/shared/inspections/trailing-slash.ts
+++ b/src/runtime/shared/inspections/trailing-slash.ts
@@ -9,7 +9,7 @@ export default function RuleTrailingSlash() {
       const $url = parseURL(link)
 
       // Ignore fragment-only links
-      if($url.pathname.startsWith('#') {
+      if($url.pathname.startsWith('#')) {
         return
       }
       

--- a/src/runtime/shared/inspections/trailing-slash.ts
+++ b/src/runtime/shared/inspections/trailing-slash.ts
@@ -9,10 +9,10 @@ export default function RuleTrailingSlash() {
       const $url = parseURL(link)
 
       // Ignore fragment-only links
-      if($url.pathname.startsWith('#')) {
+      if ($url.pathname === '' && $url.hash) {
         return
       }
-      
+
       // its a file when the last segment has a dot in it
       const isFile = $url.pathname.split('/').pop()!.includes('.')
       if ($url.pathname === '/' || isFile)

--- a/test/unit/rules/trailing-slash.test.ts
+++ b/test/unit/rules/trailing-slash.test.ts
@@ -33,4 +33,55 @@ describe('rule trailing-slash', () => {
       }
     `)
   })
+
+  it('works with fragment-only links', () => {
+    const ctx = {
+      siteConfig: {
+        trailingSlash: true,
+      },
+      response: { status: 200, statusText: 'OK', headers: {} },
+      link: '#abc',
+    } as RuleTestContext
+
+    expect(runRule(ctx, RuleTrailingSlash())).toMatchInlineSnapshot(`
+      {
+        "error": [],
+        "fix": "#abc",
+        "link": "#abc",
+        "passes": true,
+        "textContent": undefined,
+        "warning": [],
+      }
+    `)
+  })
+
+  it('works with links containing fragments', () => {
+    const ctx = {
+      siteConfig: {
+        trailingSlash: true,
+      },
+      response: { status: 200, statusText: 'OK', headers: {} },
+      link: '/a#abc',
+    } as RuleTestContext
+
+    expect(runRule(ctx, RuleTrailingSlash())).toMatchInlineSnapshot(`
+      {
+        "error": [],
+        "fix": "/a/#abc",
+        "link": "/a#abc",
+        "passes": false,
+        "textContent": undefined,
+        "warning": [
+          {
+            "fix": "/a/#abc",
+            "fixDescription": "Add trailing slash.",
+            "message": "Should have a trailing slash.",
+            "name": "trailing-slash",
+            "scope": "warning",
+            "tip": "Incorrect trailing slashes can cause duplicate pages in search engines and waste crawl budget.",
+          },
+        ],
+      }
+    `)
+  })
 })


### PR DESCRIPTION
### Description

This PR ignores links like `#abc-def` for the trailing slash link checker

### Linked Issues

Resolves #48 
