### PR TITLE
types: make `externalLinks` optional

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -6,7 +6,7 @@ import type { ComputedRef, Ref } from 'vue'
 export interface Rule {
   id: string
   test: (ctx: RuleTestContext) => void
-  externalLinks: boolean
+  externalLinks?: boolean
 }
 
 export interface RuleTestContext {


### PR DESCRIPTION
Simple PR that deals with the fact that `externalLinks` is only set for one rule though technically required at the moment.