### PR TITLE
fix: treat links with non-http protocol as external

### DIFF
--- a/playground/pages/fix-test.vue
+++ b/playground/pages/fix-test.vue
@@ -34,7 +34,7 @@
         absolute 404 link
       </LinkDebug>
       <LinkDebug to="javascript:history.back()">
-        javacript link
+        javascript link
       </LinkDebug>
       <LinkDebug to="/error">
         to an error page

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -75,7 +75,7 @@
         absolute 404 link
       </LinkDebug>
       <LinkDebug to="javascript:history.back()">
-        javacript link
+        javascript link
       </LinkDebug>
       <LinkDebug to="/error">
         to an error page

--- a/src/runtime/shared/inspect.ts
+++ b/src/runtime/shared/inspect.ts
@@ -1,5 +1,5 @@
 import type { LinkInspectionResult, Rule, RuleTestContext } from '../types'
-import { parseURL } from 'ufo'
+import { hasProtocol, parseURL } from 'ufo'
 import RuleAbsoluteSiteUrls from './inspections/absolute-site-urls'
 import RuleDescriptiveLinkText from './inspections/link-text'
 import RuleMissingHash from './inspections/missing-hash'
@@ -45,7 +45,8 @@ export function inspect(ctx: Pick<Required<RuleTestContext>, 'link'> & Omit<Part
   let processing = true
   for (const rule of validInspections) {
     const isFakeAbsolute = link.startsWith('//') && !link.includes('.')
-    const isExternalLink = url.host && url.host !== siteConfigHost && !isFakeAbsolute
+    const hasNonHttpProtocol = hasProtocol(link) && !link.startsWith('http')
+    const isExternalLink = hasNonHttpProtocol || (url.host && url.host !== siteConfigHost && !isFakeAbsolute)
     if (!rule.externalLinks && isExternalLink) {
       continue
     }

--- a/src/runtime/shared/inspections/no-javascript.ts
+++ b/src/runtime/shared/inspections/no-javascript.ts
@@ -3,6 +3,7 @@ import { defineRule } from './util'
 export default function RuleNoJavascript() {
   return defineRule({
     id: 'no-javascript',
+    externalLinks: true,
     test({ link, report }) {
       if (link.startsWith('javascript:')) {
         report({

--- a/test/e2e/generate.test.ts
+++ b/test/e2e/generate.test.ts
@@ -301,7 +301,7 @@ describe('generate', () => {
               "fix": "javascript:history.back()",
               "link": "javascript:history.back()",
               "passes": false,
-              "textContent": "javacript link"
+              "textContent": "javascript link"
             },
             {
               "error": [],
@@ -493,7 +493,7 @@ describe('generate', () => {
               "fix": "javascript:history.back()",
               "link": "javascript:history.back()",
               "passes": false,
-              "textContent": "javacript link"
+              "textContent": "javascript link"
             },
             {
               "error": [],


### PR DESCRIPTION
Main motivation for this PR is that all non-http(s) protocols are treated as internal links. This isn't exactly correct for protocols like `mailto:`, which shouldn't be subject of checks like `trailing-slash`.

Thus, I added a check similar to https://github.com/nuxt/nuxt/pull/23296 to ensure what an external/internal link might be, classifying all non-http(s) protocols as external.

I also changed the javascript link rule to check external links so it still works properly