### PR TITLE
feat: publishable reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-report.yml
@@ -14,7 +14,7 @@ body:
       required: true
     attributes:
       label: 🛠️ To reproduce
-      description: 'A reproduction of the bug. Please use the Nuxt Link Checker starter https://nuxtseo.com/link-checker/getting-started/stackblitz'
+      description: 'A reproduction of the bug. Please use submitting an issue guide https://nuxtseo.com/docs/link-checker/getting-started/troubleshooting#submitting-an-issue'
       placeholder: https://stackblitz.com/[...]
   - type: textarea
     validations:

--- a/docs/content/2.guides/3.generating-reports.md
+++ b/docs/content/2.guides/3.generating-reports.md
@@ -5,14 +5,16 @@ description: See your link checker results when you build.
 
 ## Introduction
 
-By default, links will be scanned when you run your build.
+The Nuxt Link Checker module can generate reports of the broken links in your
+application. This is useful for CI environments where you want to see the results
+of the link checker without having to run it in your local environment.
 
 ## Generating Reports
 
-To make working in a CI environment easier, you are able to generate a static
-report of the broken links.
-
-There are two reports available: `html` and `markdown`.
+There are three reports available: `html`, `markdown` and `json`.
+- `html`: a human readable report that can be opened in your browser.
+- `markdown`: can be consumed by LLMs tools or embedded within GitHub pull requests.
+- `json`: a machine readable report that can be used in your CI
 
 To generate them, you can provide the `report` option:
 
@@ -20,9 +22,10 @@ To generate them, you can provide the `report` option:
 export default defineNuxtConfig({
   linkChecker: {
     report: {
-      // generate both a html and markdown report
+      // pick and choose which reports you want to generate
       html: true,
       markdown: true,
+      json: true,
     }
   },
 })
@@ -31,3 +34,34 @@ export default defineNuxtConfig({
 The reports will be output in the following paths:
 - `html`: `./output/link-checker-report.html`
 - `markdown`: `./output/link-checker-report.md`
+- `json`: `./output/link-checker-report.json`
+
+## Publishing Public Reports
+
+Keeping your links healthy can be a lot of effort and be frustrating when you
+you are blocked in your CI pipeline due to them.
+
+For this reason, you may want to publish your link checker reports as
+publicly accessible files after your deployment. These will be non-indexable
+but directly accessible by anyone.
+
+You can make your link checker reports accessible after deployment by using the publish flag:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  linkChecker: {
+    report: {
+      publish: true
+    }
+  },
+})
+```
+
+When the publish flag is set to true, the reports will be:
+
+1. Generated during the build process
+2. Copied to your public directory
+3. Available at the following paths once deployed:
+    - HTML report: `https://example.com/__link-checker__/link-checker-report.html`
+    - Markdown report: `https://example.com/__link-checker__/link-checker-report.md`
+    - JSON report: `https://example.com/__link-checker__/link-checker-report.json`

--- a/docs/content/4.api/0.config.md
+++ b/docs/content/4.api/0.config.md
@@ -28,10 +28,12 @@ How long to wait for a response before timing out.
 
 ## `report`
 
-- Type: `{ html?: boolean; markdown?: boolean; }`
+- Type: `{ html?: boolean; markdown?: boolean; json?: boolean; publish?: boolean }`
 - Default: `undefined`
 
 Reports to generate on build.
+
+See the [Generate Reports](/docs/link-checker/guides/generate-reports) guide for more details.
 
 ## `showLiveInspections`
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -72,6 +72,7 @@ export default defineNuxtConfig({
       html: true,
       markdown: true,
       json: true,
+      publish: true,
     },
   },
 

--- a/src/build/report.ts
+++ b/src/build/report.ts
@@ -31,6 +31,7 @@ export interface InspectionContext {
   storage: Storage
   storageFilepath: string
   totalRoutes: number
+  version?: string
 }
 
 export async function generateReports(reports: PathReport[], ctx: InspectionContext) {
@@ -58,7 +59,7 @@ export async function generateReports(reports: PathReport[], ctx: InspectionCont
   }
 }
 
-async function generateHtmlReport(reports: PathReport[], { storage, storageFilepath, totalRoutes }: InspectionContext) {
+async function generateHtmlReport(reports: PathReport[], { storage, storageFilepath, totalRoutes, version }: InspectionContext) {
   const timestamp = new Date().toLocaleString()
   const totalErrors = reports.reduce((sum, { reports }) =>
     sum + reports.filter(r => r.error?.length).length, 0)
@@ -66,7 +67,6 @@ async function generateHtmlReport(reports: PathReport[], { storage, storageFilep
     sum + reports.filter(r => r.warning?.length).length, 0)
 
   // Get package version - you can add this to your module context
-  const version = process.env.npm_package_version || '1.0.0'
   const reportMeta = `
     <div class="report-meta">
       <div class="version">Nuxt Link Checker v${version}</div>

--- a/src/module.ts
+++ b/src/module.ts
@@ -62,6 +62,12 @@ export interface ModuleOptions {
      * By default, they'll be in your .output directory.
      */
     storage?: string | CreateStorageOptions
+    /**
+     * Whether to publish the reports with the build.
+     *
+     * By default, will output files at `.output/public/__link-checker__/link-checker-report.<format>`.
+     */
+    publish?: boolean
   }
   /**
    * Whether to show live inspections in your Nuxt app.
@@ -208,7 +214,7 @@ export default defineNuxtModule<ModuleOptions>({
         // disable no-error-response
         config.skipInspections.push('no-error-response')
       }
-      prerender(config)
+      prerender(config, version)
     }
   },
 })


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Keeping your links healthy can be a lot of effort and be frustrating when you
you are blocked in your CI pipeline due to them.

For this reason, you may want to publish your link checker reports as
publicly accessible files after your deployment. These will be non-indexable
but directly accessible by anyone.

You can make your link checker reports accessible after deployment by using the publish flag:

```ts [nuxt.config.ts]
export default defineNuxtConfig({
  linkChecker: {
    report: {
      publish: true
    }
  },
})
```

When the publish flag is set to true, the reports will be:

1. Generated during the build process
2. Copied to your public directory
3. Available at the following paths once deployed:
    - HTML report: `https://example.com/__link-checker__/link-checker-report.html`
    - Markdown report: `https://example.com/__link-checker__/link-checker-report.md`
    - JSON report: `https://example.com/__link-checker__/link-checker-report.json`


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
