### PR TITLE
feat(prerender): re-enable default 404 link checking

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -55,6 +55,7 @@ export default defineNuxtConfig({
       routes: [
         '/',
       ],
+      crawlLinks: true,
       failOnError: false,
     },
   },
@@ -68,6 +69,7 @@ export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: ['/ignored'],
     skipInspections: ['missing-hash'],
+    debug: true,
     report: {
       html: true,
       markdown: true,

--- a/playground/pages/error.vue
+++ b/playground/pages/error.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 createError({
-  statusCode: 404,
-  statusMessage: 'Page not found',
+  statusCode: 500,
+  statusMessage: '500 eror page',
   fatal: true,
 })
 </script>

--- a/src/build/util.ts
+++ b/src/build/util.ts
@@ -1,0 +1,40 @@
+export async function runParallel<T>(
+  inputs: Set<T>,
+  cb: (input: T) => unknown | Promise<unknown>,
+  opts: { concurrency: number, interval?: number },
+) {
+  const tasks = new Set<Promise<unknown>>()
+
+  function queueNext(): undefined | Promise<unknown> {
+    const route = inputs.values().next().value
+    if (!route) {
+      return
+    }
+
+    inputs.delete(route)
+    const task = (
+      opts.interval
+        ? new Promise(resolve => setTimeout(resolve, opts.interval))
+        : Promise.resolve()
+    )
+      .then(() => cb(route))
+      .catch((error) => {
+        console.error(error)
+      })
+
+    tasks.add(task)
+    return task.then(() => {
+      tasks.delete(task)
+      if (inputs.size > 0) {
+        return refillQueue()
+      }
+    })
+  }
+
+  function refillQueue(): Promise<unknown> {
+    const workers = Math.min(opts.concurrency - tasks.size, inputs.size)
+    return Promise.all(Array.from({ length: workers }, () => queueNext()))
+  }
+
+  await refillQueue()
+}

--- a/src/runtime/shared/crawl.ts
+++ b/src/runtime/shared/crawl.ts
@@ -1,26 +1,36 @@
-import { $fetch } from 'ofetch'
 import { isNonFetchableLink } from './inspections/util'
 
-const responses: Record<string, Promise<{ status: number, statusText: string, headers: Record<string, any> }>> = {}
+type MaybePromise<T> = T | Promise<T>
+
+interface LinkResponse { status: number, statusText: string, headers: Record<string, any> }
+
+const responses: Record<string, MaybePromise<LinkResponse>> = {}
+
+const MockSuccessResponse = Promise.resolve({ status: 200, statusText: 'OK', headers: {} })
+
 export async function getLinkResponse({ link, timeout, fetchRemoteUrls, baseURL, isInStorage }: { link: string, baseURL?: string, timeout?: number, fetchRemoteUrls?: boolean, isInStorage: () => boolean }) {
   // if the link has an anchor on it, do the request without the anchor
   if (link.includes('#') && !link.startsWith('#'))
     link = link.split('#')[0]
   link = decodeURI(link)
-  const response = responses[link]
-  if (!response) {
-    if (isNonFetchableLink(link)
-      // skip remote urls if we're not allowed to fetch them
-      || (link.startsWith('http') && !fetchRemoteUrls)
-      || isInStorage()
-    ) {
-      responses[link] = Promise.resolve({ status: 200, statusText: 'OK', headers: {} })
-    }
-    else {
-      // do fetch
-      responses[link] = crawlFetch(link, { timeout, baseURL })
-    }
+  if (link in responses) {
+    return responses[link]
   }
+  if (isNonFetchableLink(link)) {
+    return null
+  }
+  if (isInStorage()) {
+    responses[link] = Promise.resolve({ status: 200, statusText: 'OK', headers: { 'X-Nuxt-Prerendered': true } })
+    return responses[link]
+  }
+  // handle absolute links
+  if (link.startsWith('http') || link.startsWith('//')) {
+    // TODO check they don't include the site URL
+    responses[link] = fetchRemoteUrls ? crawlFetch(link, { timeout, baseURL }) : MockSuccessResponse
+    return responses[link]
+  }
+  // relative link in dev?
+  responses[link] = crawlFetch(link, { timeout, baseURL })
   return responses[link]
 }
 
@@ -28,14 +38,26 @@ export function setLinkResponse(link: string, response: Promise<{ status: number
   responses[link] = response
 }
 
+export async function getResolvedLinkResponses() {
+  // wait for all responses to resolve
+  const data: Record<string, LinkResponse> = {}
+  for (const link in responses) {
+    data[link] = await responses[link]
+  }
+  return data
+}
+
 export async function crawlFetch(link: string, options: { timeout?: number, baseURL?: string } = {}) {
   const timeout = options.timeout || 5000
   const timeoutController = new AbortController()
   const abortRequestTimeout = setTimeout(() => timeoutController.abort(), timeout)
-  return await $fetch.raw(encodeURI(link), {
+  const start = Date.now()
+  return await globalThis.$fetch.raw(encodeURI(link), {
     baseURL: options.baseURL,
     method: 'HEAD',
     signal: timeoutController.signal,
+    retry: 3,
+    retryDelay: 250,
     headers: {
       'user-agent': 'Nuxt Link Checker',
     },
@@ -47,5 +69,19 @@ export async function crawlFetch(link: string, options: { timeout?: number, base
       return { status: 404, statusText: 'Not Found', headers: {} }
     })
     .finally(() => clearTimeout(abortRequestTimeout))
-    .then(res => ({ status: res.status, statusText: res.statusText, headers: res.headers }))
+    .then((res: Response) => {
+      let headersObj: Record<string, string> = {}
+
+      if (res.headers) {
+        // If headers is a Headers object with entries method
+        if (typeof res.headers.entries === 'function') {
+          headersObj = Object.fromEntries(Array.from(res.headers.entries()))
+        }
+        // If headers is already a plain object
+        else if (typeof res.headers === 'object') {
+          headersObj = { ...res.headers }
+        }
+      }
+      return { status: res.status, statusText: res.statusText, headers: headersObj, time: Date.now() - start }
+    })
 }

--- a/src/runtime/shared/inspections/no-error-response.ts
+++ b/src/runtime/shared/inspections/no-error-response.ts
@@ -6,7 +6,7 @@ export default function RuleNoErrorResponse() {
     id: 'no-error-response',
     externalLinks: true,
     test({ link, response, report, pageSearch }) {
-      if (!response.status || response.status.toString().startsWith('2') || response.status.toString().startsWith('3') || isNonFetchableLink(link))
+      if (!response?.status || response.status.toString().startsWith('2') || response.status.toString().startsWith('3') || isNonFetchableLink(link))
         return
       const payload: RuleReport = {
         name: 'no-error-response',

--- a/src/runtime/shared/redirects.ts
+++ b/src/runtime/shared/redirects.ts
@@ -5,7 +5,7 @@ export default function RuleRedirects() {
   return defineRule({
     id: 'redirects',
     test({ report, response }) {
-      if (response.status !== 301 && response.status !== 302)
+      if (response?.status !== 301 && response?.status !== 302)
         return
 
       const payload: RuleReport = {

--- a/test/e2e/generate.test.ts
+++ b/test/e2e/generate.test.ts
@@ -27,373 +27,6 @@ describe('generate', () => {
     expect(reportJson).toMatchInlineSnapshot(`
       "[
         {
-          "route": "/",
-          "reports": [
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/",
-              "link": "/",
-              "passes": true,
-              "textContent": "Nuxt nuxt-link-checker-playground"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/#anchor",
-              "link": "/#anchor",
-              "passes": true,
-              "textContent": "valid anchor"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/valid",
-              "link": "/valid",
-              "passes": true,
-              "textContent": "valid link"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/redirect",
-              "link": "/redirect",
-              "passes": true,
-              "textContent": "valid link to redirect"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "link": "/ignored"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "mailto:harlan@harlanzw.com",
-              "link": "mailto:harlan@harlanzw.com",
-              "passes": true,
-              "textContent": "mail to link"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/some-file.pdf",
-              "link": "/some-file.pdf",
-              "passes": true,
-              "textContent": "file link"
-            },
-            {
-              "error": [],
-              "warning": [
-                {
-                  "name": "no-uppercase-chars",
-                  "scope": "warning",
-                  "message": "Links should not contain uppercase characters.",
-                  "fix": "/about/billy%20bob",
-                  "fixDescription": "Convert to lowercase."
-                }
-              ],
-              "fix": "/about/billy%20bob",
-              "link": "/about/Billy%20Bob",
-              "passes": false,
-              "textContent": "Dynamic Encoded Path"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "link": ""
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Not Found)."
-                }
-              ],
-              "warning": [
-                {
-                  "name": "no-double-slashes",
-                  "scope": "warning",
-                  "message": "Links should not contain double slashes.",
-                  "fix": "/oops",
-                  "fixDescription": "Remove double slashes."
-                }
-              ],
-              "fix": "/oops",
-              "link": "//oops",
-              "passes": false,
-              "textContent": "double slash"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Not Found)."
-                }
-              ],
-              "warning": [
-                {
-                  "name": "no-double-slashes",
-                  "scope": "warning",
-                  "message": "Links should not contain double slashes.",
-                  "fix": "/oops",
-                  "fixDescription": "Remove double slashes."
-                }
-              ],
-              "fix": "/oops",
-              "link": "//oops",
-              "passes": false,
-              "textContent": "double slash"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found)."
-                }
-              ],
-              "warning": [
-                {
-                  "name": "no-non-ascii-chars",
-                  "scope": "warning",
-                  "message": "Links should not contain non-ascii characters.",
-                  "fix": "/users/%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A6/photos/%F0%9F%8C%85-vacation",
-                  "fixDescription": "Encode non-ascii characters."
-                },
-                {
-                  "name": "no-uppercase-chars",
-                  "scope": "warning",
-                  "message": "Links should not contain uppercase characters.",
-                  "fix": "/users/%f0%9f%91%a8%e2%80%8d%f0%9f%91%a9%e2%80%8d%f0%9f%91%a6/photos/%f0%9f%8c%85-vacation",
-                  "fixDescription": "Convert to lowercase."
-                }
-              ],
-              "fix": "/users/%f0%9f%91%a8%e2%80%8d%f0%9f%91%a9%e2%80%8d%f0%9f%91%a6/photos/%f0%9f%8c%85-vacation",
-              "link": "/users/👨‍👩‍👦/photos/🌅-vacation",
-              "passes": false,
-              "textContent": "non-ascii"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found).",
-                  "fix": "/foo",
-                  "fixDescription": "Did you mean /foo?"
-                }
-              ],
-              "warning": [
-                {
-                  "name": "no-whitespace",
-                  "scope": "warning",
-                  "message": "Links should not contain whitespace.",
-                  "tip": "Use hyphens to separate words instead of spaces."
-                }
-              ],
-              "fix": "/foo",
-              "link": "/ oops",
-              "passes": false,
-              "textContent": "whitespace"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found)."
-                }
-              ],
-              "warning": [],
-              "fix": "/oopsthisisamistake",
-              "link": "/oopsthisisamistake",
-              "passes": false,
-              "textContent": "uppercase"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Not Found).",
-                  "canRetry": true
-                }
-              ],
-              "warning": [
-                {
-                  "name": "no-whitespace",
-                  "scope": "warning",
-                  "message": "Links should not contain whitespace.",
-                  "tip": "Use hyphens to separate words instead of spaces."
-                },
-                {
-                  "name": "no-baseless",
-                  "scope": "warning",
-                  "message": "Links should be root relative.",
-                  "fix": "/this is a very bad link",
-                  "fixDescription": "Add base /."
-                }
-              ],
-              "fix": "/this is a very bad link",
-              "link": "this is a very bad link",
-              "passes": false,
-              "textContent": "very bad link"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found).",
-                  "fix": "/about",
-                  "fixDescription": "Did you mean /about?"
-                }
-              ],
-              "warning": [],
-              "fix": "/about",
-              "link": "/abot",
-              "passes": false,
-              "textContent": "page typo with magic fix"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/#broken-anchor",
-              "link": "/#broken-anchor",
-              "passes": true,
-              "textContent": "broken anchor"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found)."
-                }
-              ],
-              "warning": [],
-              "fix": "/404link",
-              "link": "/404link",
-              "passes": false,
-              "textContent": "404 links"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "https://example.com/absolute",
-              "link": "https://example.com/absolute",
-              "passes": true,
-              "textContent": "absolute 404 link"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-javascript",
-                  "scope": "error",
-                  "tip": "Using a <button type=\\"button\\"> instead as a better practice.",
-                  "message": "Should not use JavaScript"
-                }
-              ],
-              "warning": [],
-              "fix": "javascript:history.back()",
-              "link": "javascript:history.back()",
-              "passes": false,
-              "textContent": "javascript link"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/error",
-              "link": "/error",
-              "passes": true,
-              "textContent": "to an error page"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found)."
-                }
-              ],
-              "warning": [
-                {
-                  "name": "trailing-slash",
-                  "scope": "warning",
-                  "message": "Should not have a trailing slash.",
-                  "tip": "Incorrect trailing slashes can cause duplicate pages in search engines and waste crawl budget.",
-                  "fix": "/completely-broken",
-                  "fixDescription": "Removing trailing slash."
-                }
-              ],
-              "fix": "/completely-broken",
-              "link": "/completely-broken/",
-              "passes": false,
-              "textContent": "error and warning"
-            },
-            {
-              "error": [
-                {
-                  "name": "no-error-response",
-                  "scope": "error",
-                  "message": "Should not respond with status code 404 (Page not found).",
-                  "fix": "/about",
-                  "fixDescription": "Did you mean /about?"
-                }
-              ],
-              "warning": [],
-              "fix": "/about",
-              "link": "/abt",
-              "passes": false,
-              "textContent": "page typo with magic fix - AGAIN 123"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "https://nuxt.com/docs/",
-              "link": "https://nuxt.com/docs/",
-              "passes": true,
-              "textContent": "nuxt.com - remote URL"
-            },
-            {
-              "error": [],
-              "warning": [
-                {
-                  "name": "trailing-slash",
-                  "scope": "warning",
-                  "message": "Should not have a trailing slash.",
-                  "tip": "Incorrect trailing slashes can cause duplicate pages in search engines and waste crawl budget.",
-                  "fix": "/trailingslash",
-                  "fixDescription": "Removing trailing slash."
-                }
-              ],
-              "fix": "/trailingslash",
-              "link": "/trailingslash/",
-              "passes": false,
-              "textContent": "trailing slash"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "/redirect",
-              "link": "/redirect",
-              "passes": true,
-              "textContent": "redirect link"
-            },
-            {
-              "error": [],
-              "warning": [],
-              "fix": "https://nuxt-link-checker.com/about",
-              "link": "https://nuxt-link-checker.com/about",
-              "passes": true,
-              "textContent": "Absolute internal link"
-            }
-          ]
-        },
-        {
           "route": "/fix-test",
           "reports": [
             {
@@ -559,6 +192,361 @@ describe('generate', () => {
               "textContent": "Absolute internal link"
             }
           ]
+        },
+        {
+          "route": "/",
+          "reports": [
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/",
+              "link": "/",
+              "passes": true,
+              "textContent": "Nuxt nuxt-link-checker-playground"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/#anchor",
+              "link": "/#anchor",
+              "passes": true,
+              "textContent": "valid anchor"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/valid",
+              "link": "/valid",
+              "passes": true,
+              "textContent": "valid link"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/redirect",
+              "link": "/redirect",
+              "passes": true,
+              "textContent": "valid link to redirect"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "link": "/ignored"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "mailto:harlan@harlanzw.com",
+              "link": "mailto:harlan@harlanzw.com",
+              "passes": true,
+              "textContent": "mail to link"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/some-file.pdf",
+              "link": "/some-file.pdf",
+              "passes": true,
+              "textContent": "file link"
+            },
+            {
+              "error": [],
+              "warning": [
+                {
+                  "name": "no-uppercase-chars",
+                  "scope": "warning",
+                  "message": "Links should not contain uppercase characters.",
+                  "fix": "/about/billy%20bob",
+                  "fixDescription": "Convert to lowercase."
+                }
+              ],
+              "fix": "/about/billy%20bob",
+              "link": "/about/Billy%20Bob",
+              "passes": false,
+              "textContent": "Dynamic Encoded Path"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "link": ""
+            },
+            {
+              "error": [],
+              "warning": [
+                {
+                  "name": "no-double-slashes",
+                  "scope": "warning",
+                  "message": "Links should not contain double slashes.",
+                  "fix": "/oops",
+                  "fixDescription": "Remove double slashes."
+                }
+              ],
+              "fix": "/oops",
+              "link": "//oops",
+              "passes": false,
+              "textContent": "double slash"
+            },
+            {
+              "error": [],
+              "warning": [
+                {
+                  "name": "no-double-slashes",
+                  "scope": "warning",
+                  "message": "Links should not contain double slashes.",
+                  "fix": "/oops",
+                  "fixDescription": "Remove double slashes."
+                }
+              ],
+              "fix": "/oops",
+              "link": "//oops",
+              "passes": false,
+              "textContent": "double slash"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found)."
+                }
+              ],
+              "warning": [
+                {
+                  "name": "no-non-ascii-chars",
+                  "scope": "warning",
+                  "message": "Links should not contain non-ascii characters.",
+                  "fix": "/users/%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A6/photos/%F0%9F%8C%85-vacation",
+                  "fixDescription": "Encode non-ascii characters."
+                },
+                {
+                  "name": "no-uppercase-chars",
+                  "scope": "warning",
+                  "message": "Links should not contain uppercase characters.",
+                  "fix": "/users/%f0%9f%91%a8%e2%80%8d%f0%9f%91%a9%e2%80%8d%f0%9f%91%a6/photos/%f0%9f%8c%85-vacation",
+                  "fixDescription": "Convert to lowercase."
+                }
+              ],
+              "fix": "/users/%f0%9f%91%a8%e2%80%8d%f0%9f%91%a9%e2%80%8d%f0%9f%91%a6/photos/%f0%9f%8c%85-vacation",
+              "link": "/users/👨‍👩‍👦/photos/🌅-vacation",
+              "passes": false,
+              "textContent": "non-ascii"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found).",
+                  "fix": "/foo",
+                  "fixDescription": "Did you mean /foo?"
+                }
+              ],
+              "warning": [
+                {
+                  "name": "no-whitespace",
+                  "scope": "warning",
+                  "message": "Links should not contain whitespace.",
+                  "tip": "Use hyphens to separate words instead of spaces."
+                }
+              ],
+              "fix": "/foo",
+              "link": "/ oops",
+              "passes": false,
+              "textContent": "whitespace"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found)."
+                }
+              ],
+              "warning": [],
+              "fix": "/oopsthisisamistake",
+              "link": "/oopsthisisamistake",
+              "passes": false,
+              "textContent": "uppercase"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found).",
+                  "fix": "/about",
+                  "fixDescription": "Did you mean /about?"
+                }
+              ],
+              "warning": [],
+              "fix": "/about",
+              "link": "/abot",
+              "passes": false,
+              "textContent": "page typo with magic fix"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/#broken-anchor",
+              "link": "/#broken-anchor",
+              "passes": true,
+              "textContent": "broken anchor"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found)."
+                }
+              ],
+              "warning": [],
+              "fix": "/404link",
+              "link": "/404link",
+              "passes": false,
+              "textContent": "404 links"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "https://example.com/absolute",
+              "link": "https://example.com/absolute",
+              "passes": true,
+              "textContent": "absolute 404 link"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-javascript",
+                  "scope": "error",
+                  "tip": "Using a <button type=\\"button\\"> instead as a better practice.",
+                  "message": "Should not use JavaScript"
+                }
+              ],
+              "warning": [],
+              "fix": "javascript:history.back()",
+              "link": "javascript:history.back()",
+              "passes": false,
+              "textContent": "javascript link"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/error",
+              "link": "/error",
+              "passes": true,
+              "textContent": "to an error page"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found)."
+                }
+              ],
+              "warning": [
+                {
+                  "name": "trailing-slash",
+                  "scope": "warning",
+                  "message": "Should not have a trailing slash.",
+                  "tip": "Incorrect trailing slashes can cause duplicate pages in search engines and waste crawl budget.",
+                  "fix": "/completely-broken",
+                  "fixDescription": "Removing trailing slash."
+                }
+              ],
+              "fix": "/completely-broken",
+              "link": "/completely-broken/",
+              "passes": false,
+              "textContent": "error and warning"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Page not found).",
+                  "fix": "/about",
+                  "fixDescription": "Did you mean /about?"
+                }
+              ],
+              "warning": [],
+              "fix": "/about",
+              "link": "/abt",
+              "passes": false,
+              "textContent": "page typo with magic fix - AGAIN 123"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "https://nuxt.com/docs/",
+              "link": "https://nuxt.com/docs/",
+              "passes": true,
+              "textContent": "nuxt.com - remote URL"
+            },
+            {
+              "error": [],
+              "warning": [
+                {
+                  "name": "trailing-slash",
+                  "scope": "warning",
+                  "message": "Should not have a trailing slash.",
+                  "tip": "Incorrect trailing slashes can cause duplicate pages in search engines and waste crawl budget.",
+                  "fix": "/trailingslash",
+                  "fixDescription": "Removing trailing slash."
+                }
+              ],
+              "fix": "/trailingslash",
+              "link": "/trailingslash/",
+              "passes": false,
+              "textContent": "trailing slash"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "/redirect",
+              "link": "/redirect",
+              "passes": true,
+              "textContent": "redirect link"
+            },
+            {
+              "error": [],
+              "warning": [],
+              "fix": "https://nuxt-link-checker.com/about",
+              "link": "https://nuxt-link-checker.com/about",
+              "passes": true,
+              "textContent": "Absolute internal link"
+            },
+            {
+              "error": [
+                {
+                  "name": "no-error-response",
+                  "scope": "error",
+                  "message": "Should not respond with status code 404 (Not Found).",
+                  "canRetry": true
+                }
+              ],
+              "warning": [
+                {
+                  "name": "no-whitespace",
+                  "scope": "warning",
+                  "message": "Links should not contain whitespace.",
+                  "tip": "Use hyphens to separate words instead of spaces."
+                },
+                {
+                  "name": "no-baseless",
+                  "scope": "warning",
+                  "message": "Links should be root relative.",
+                  "fix": "/this is a very bad link",
+                  "fixDescription": "Add base /."
+                }
+              ],
+              "fix": "/this is a very bad link",
+              "link": "this is a very bad link",
+              "passes": false,
+              "textContent": "very bad link"
+            }
+          ]
         }
       ]"
     `)
@@ -572,19 +560,49 @@ describe('generate', () => {
       ## Summary
 
       - **Pages checked:** 2
-      - **Total errors:** 15
+      - **Total errors:** 13
       - **Total warnings:** 10
 
       ---
 
       ## Table of Contents
 
-      - [/](#)
       - [/fix-test](#fix-test)
+      - [/](#)
 
       ---
 
-      ## ❌ [/](/) (11 errors, 8 warnings)
+      ## ❌ [/fix-test](/fix-test) (4 errors, 2 warnings)
+
+      ### Link: [/abt](/abt)
+      > Link text: "page typo with magic fix"
+      #### Errors
+      - **no-error-response:** Should not respond with status code 404 (Page not found).
+        - *Suggestion:* Did you mean /about?
+      ### Link: [/404link/](/404link/)
+      > Link text: "404 links"
+      #### Errors
+      - **no-error-response:** Should not respond with status code 404 (Page not found).
+      #### Warnings
+      - **trailing-slash:** Should not have a trailing slash.
+        - *Suggestion:* Removing trailing slash.
+      ### Link: [javascript:history.back()](javascript:history.back())
+      > Link text: "javascript link"
+      #### Errors
+      - **no-javascript:** Should not use JavaScript
+      ### Link: [/completely-broken/](/completely-broken/)
+      > Link text: "error and warning"
+      #### Errors
+      - **no-error-response:** Should not respond with status code 404 (Page not found).
+      #### Warnings
+      - **trailing-slash:** Should not have a trailing slash.
+        - *Suggestion:* Removing trailing slash.
+
+      <div align="right"><a href="#nuxt-link-checker-report">↑ Back to top</a></div>
+
+      ---
+
+      ## ❌ [/](/) (9 errors, 8 warnings)
 
       ### Link: [/about/Billy%20Bob](/about/Billy%20Bob)
       > Link text: "Dynamic Encoded Path"
@@ -593,9 +611,6 @@ describe('generate', () => {
         - *Suggestion:* Convert to lowercase.
       ### Link: [//oops](//oops)
       > Link text: "double slash"
-      #### Errors
-      - **no-error-response:** Should not respond with status code 404 (Not Found).
-      - **no-error-response:** Should not respond with status code 404 (Not Found).
       #### Warnings
       - **no-double-slashes:** Links should not contain double slashes.
         - *Suggestion:* Remove double slashes.
@@ -621,14 +636,6 @@ describe('generate', () => {
       > Link text: "uppercase"
       #### Errors
       - **no-error-response:** Should not respond with status code 404 (Page not found).
-      ### Link: [this is a very bad link](this is a very bad link)
-      > Link text: "very bad link"
-      #### Errors
-      - **no-error-response:** Should not respond with status code 404 (Not Found).
-      #### Warnings
-      - **no-whitespace:** Links should not contain whitespace.
-      - **no-baseless:** Links should be root relative.
-        - *Suggestion:* Add base /.
       ### Link: [/abot](/abot)
       > Link text: "page typo with magic fix"
       #### Errors
@@ -659,36 +666,14 @@ describe('generate', () => {
       #### Warnings
       - **trailing-slash:** Should not have a trailing slash.
         - *Suggestion:* Removing trailing slash.
-
-      <div align="right"><a href="#nuxt-link-checker-report">↑ Back to top</a></div>
-
-      ---
-
-      ## ❌ [/fix-test](/fix-test) (4 errors, 2 warnings)
-
-      ### Link: [/abt](/abt)
-      > Link text: "page typo with magic fix"
+      ### Link: [this is a very bad link](this is a very bad link)
+      > Link text: "very bad link"
       #### Errors
-      - **no-error-response:** Should not respond with status code 404 (Page not found).
-        - *Suggestion:* Did you mean /about?
-      ### Link: [/404link/](/404link/)
-      > Link text: "404 links"
-      #### Errors
-      - **no-error-response:** Should not respond with status code 404 (Page not found).
+      - **no-error-response:** Should not respond with status code 404 (Not Found).
       #### Warnings
-      - **trailing-slash:** Should not have a trailing slash.
-        - *Suggestion:* Removing trailing slash.
-      ### Link: [javascript:history.back()](javascript:history.back())
-      > Link text: "javascript link"
-      #### Errors
-      - **no-javascript:** Should not use JavaScript
-      ### Link: [/completely-broken/](/completely-broken/)
-      > Link text: "error and warning"
-      #### Errors
-      - **no-error-response:** Should not respond with status code 404 (Page not found).
-      #### Warnings
-      - **trailing-slash:** Should not have a trailing slash.
-        - *Suggestion:* Removing trailing slash.
+      - **no-whitespace:** Links should not contain whitespace.
+      - **no-baseless:** Links should be root relative.
+        - *Suggestion:* Add base /.
 
       <div align="right"><a href="#nuxt-link-checker-report">↑ Back to top</a></div>
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the external link checker was originally enabled for remote URLs is was very flakey which led to it being disabled by default when building.

Through the implementation of batch processing and fetch retries, it seems like a good time to re-enable this by default as it now seems more stable.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
