### PR TITLE
fix: check for `vbscript:`

### DIFF
--- a/src/runtime/shared/inspections/util.ts
+++ b/src/runtime/shared/inspections/util.ts
@@ -5,7 +5,8 @@ export function defineRule(rule: Rule) {
 }
 
 export function isNonFetchableLink(link: string) {
-  return link.startsWith('javascript:') || link.startsWith('blob:') || link.startsWith('data:') || link.startsWith('mailto:')
-    || link.startsWith('tel:')
-    || link.startsWith('#')
+  const trimmedLink = link.trim().toLowerCase();
+  return trimmedLink.startsWith('javascript:') || trimmedLink.startsWith('blob:') || trimmedLink.startsWith('data:') || trimmedLink.startsWith('mailto:')
+    || trimmedLink.startsWith('tel:') || trimmedLink.startsWith('vbscript:')
+    || trimmedLink.startsWith('#');
 }


### PR DESCRIPTION
Potential fix for [https://github.com/harlan-zw/nuxt-link-checker/security/code-scanning/2](https://github.com/harlan-zw/nuxt-link-checker/security/code-scanning/2)

To fix the problem, we need to extend the existing URL scheme checks to include `vbscript:`. This will ensure that URLs starting with `vbscript:` are also considered non-fetchable, thereby mitigating the risk of executing harmful code.

- Modify the `isNonFetchableLink` function to include a check for `vbscript:`.
- Ensure the check is case-insensitive and handles potential leading whitespace by trimming and converting the URL to lowercase before performing the checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
