### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -97,7 +97,7 @@ function getTextContent(node: any): string {
 }
 
 export function isNuxtGenerate(nuxt: Nuxt = useNuxt()) {
-  return nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ || nuxt.options.nitro.static || nuxt.options.nitro.preset === 'static'
+  return (nuxt.options as any)._generate /* TODO: remove in future */ || nuxt.options.nitro.static || nuxt.options.nitro.preset === 'static'
 }
 
 export function prerender(config: ModuleOptions, version?: string, nuxt = useNuxt()) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -97,7 +97,7 @@ function getTextContent(node: any): string {
 }
 
 export function isNuxtGenerate(nuxt: Nuxt = useNuxt()) {
-  return nuxt.options._generate || nuxt.options.nitro.static || nuxt.options.nitro.preset === 'static'
+  return nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ || nuxt.options.nitro.static || nuxt.options.nitro.preset === 'static'
 }
 
 export function prerender(config: ModuleOptions, version?: string, nuxt = useNuxt()) {


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
