### PR TITLE
docs: fix internal links to use correct paths

### DIFF
--- a/docs/content/4.releases/6.v2.md
+++ b/docs/content/4.releases/6.v2.md
@@ -39,7 +39,7 @@ See the [build reports](/docs/link-checker/guides/build-scans) guide for more in
 - `trailingSlash` has been deprecated
 - `siteUrl` has been deprecated
 
-These should now be configured using [site config](/docs/site-config/guides/setting-site-config).
+These should now be configured using [site config](/docs/site-config/guides/how-it-works).
 
 ## ⚠️ Breaking Changes
 


### PR DESCRIPTION
## Summary
- Fix `setting-site-config` → `how-it-works`

These links were causing unnecessary redirects on nuxtseo.com.

🤖 Generated with [Claude Code](https://claude.ai/code)