### PR TITLE
feat: show source file paths in link inspection console output

### DIFF
--- a/src/build/report.ts
+++ b/src/build/report.ts
@@ -33,6 +33,7 @@ export interface InspectionContext {
   totalRoutes: number
   version?: string
   isPrerenderingAllRoutes: boolean
+  routeFileMap: Record<string, string>
 }
 
 export async function generateReports(reports: PathReport[], ctx: InspectionContext): Promise<void> {

--- a/src/module.ts
+++ b/src/module.ts
@@ -248,6 +248,15 @@ export default defineNuxtModule<ModuleOptions>({
       setupDevToolsUI(config, resolve)
     }
 
+    // Collect route-to-file mapping for console output (#43)
+    const routeFileMap: Record<string, string> = {}
+    nuxt.hooks.hook('pages:resolved', (resolved) => {
+      for (const entry of convertNuxtPagesToPaths(resolved)) {
+        if (entry.file)
+          routeFileMap[entry.link] = entry.file
+      }
+    })
+
     // ESLint integration: write route data for eslint rules
     const routesDir = join(nuxt.options.buildDir, 'link-checker')
     const routesPath = join(routesDir, 'routes.json')
@@ -329,7 +338,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     if (config.runOnBuild) {
-      prerender(config, version)
+      prerender(config, version, routeFileMap)
     }
   },
 })

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -98,7 +98,7 @@ function getTextContent(node: any): string {
   return text.filter(Boolean).map(s => s.trim()).join(' ')
 }
 
-export function prerender(config: ModuleOptions, version?: string, nuxt = useNuxt()): void {
+export function prerender(config: ModuleOptions, version?: string, routeFileMap: Record<string, string> = {}, nuxt = useNuxt()): void {
   if (config.report?.publish) {
     // make paths non indexable using X-Robots-Tag
     nuxt.options.nitro.routeRules = nuxt.options.nitro.routeRules || {}
@@ -156,6 +156,7 @@ export function prerender(config: ModuleOptions, version?: string, nuxt = useNux
         storageFilepath,
         isPrerenderingAllRoutes: isNuxtGenerate(nuxt) || Boolean(nuxt.options.nitro.prerender?.crawlLinks),
         totalRoutes: payloads.length,
+        routeFileMap,
       } satisfies InspectionContext
       const { allReports, errorCount } = await runInspections(payloads, inspectionCtx)
 
@@ -247,7 +248,7 @@ async function runInspections(
 
         // Only log detailed results if reports are not enabled
         if (!hasReportsEnabled(config)) {
-          logRouteIssues(route, reports, routeErrors, routeWarnings, nitro)
+          logRouteIssues(route, reports, routeErrors, routeWarnings, nitro, context.routeFileMap)
         }
       }
 
@@ -374,14 +375,16 @@ function logRouteIssues(
   errors: number,
   warnings: number,
   nitro: Nitro,
+  routeFileMap: Record<string, string> = {},
 ): void {
   const statusString = [
     errors > 0 ? red(`${errors} error${errors > 1 ? 's' : ''}`) : false,
     warnings > 0 ? yellow(`${warnings} warning${warnings > 1 ? 's' : ''}`) : false,
   ].filter(Boolean).join(gray(', '))
 
+  const filePath = routeFileMap[route]
   nitro.logger.log(gray(''))
-  nitro.logger.log(`${white(route)} ${gray('[')}${statusString}${gray(']')}`)
+  nitro.logger.log(`${white(route)} ${gray('[')}${statusString}${gray(']')}${filePath ? ` ${dim(filePath)}` : ''}`)
 
   const reportsByLink = groupReportsByLink(reports)
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,7 @@ import type { WebSocketServer } from 'vite'
 import { useNuxt } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 
-export function convertNuxtPagesToPaths(pages: NuxtPage[], options?: { keepDynamic?: boolean }): { title: string, link: string }[] {
+export function convertNuxtPagesToPaths(pages: NuxtPage[], options?: { keepDynamic?: boolean }): { title: string, link: string, file?: string }[] {
   return pages
     .map((page) => {
       return page.children?.length
@@ -21,6 +21,7 @@ export function convertNuxtPagesToPaths(pages: NuxtPage[], options?: { keepDynam
     .map(p => ({
       title: p.page?.meta?.title || '',
       link: p.path,
+      file: p.page?.file,
     }))
 }
 


### PR DESCRIPTION
## Summary

- Resolves route-to-file mapping from `NuxtPage` data via `convertNuxtPagesToPaths` and passes it through the prerender pipeline
- Displays the source file path (dimmed) next to each route in the build console output when link issues are found
- Adds `routeFileMap` to `InspectionContext` and extends `convertNuxtPagesToPaths` return type to include optional `file` field

Closes #43

## Test plan

- [ ] Run `nuxt generate` on a project with link errors and verify file paths appear next to route names in the console
- [ ] Confirm routes without a matching file (e.g. dynamic or content-driven) display without a file path
- [ ] Verify no regressions in report generation (HTML, Markdown, JSON)