### PR TITLE
feat: add `excludePages` config to skip link checking on specific pages

### DIFF
--- a/docs/content/2.guides/3.exclude-pages.md
+++ b/docs/content/2.guides/3.exclude-pages.md
@@ -1,0 +1,31 @@
+---
+title: Exclude Pages
+description: Exclude entire pages from link checking.
+---
+
+Exclude pages from link checking using the `excludePages` option. When a page matches, none of its links will be inspected.
+
+This is useful when a page renders many external links you don't control or when an entire section of your site should be skipped.
+
+## Usage
+
+```ts
+export default defineNuxtConfig({
+  linkChecker: {
+    excludePages: [
+      '/external-links', // Exact match
+      '/embed/**', // All embed routes
+      /^\/generated\//, // RegExp pattern
+    ],
+  },
+})
+```
+
+The same pattern types are supported as [`excludeLinks`](/docs/link-checker/guides/exclude-links): exact strings, wildcards, and RegExp.
+
+## Difference from excludeLinks
+
+| Option | Effect |
+|---|---|
+| `excludeLinks` | Skips specific link URLs from being checked on **any** page |
+| `excludePages` | Skips **all** link checking on matched pages |

--- a/src/build/report.ts
+++ b/src/build/report.ts
@@ -23,6 +23,7 @@ export interface ExtractedPayload {
 
 export interface InspectionContext {
   urlFilter: (url: string) => boolean
+  pageFilter: (url: string) => boolean
   config: ModuleOptions
   nuxt: Nuxt
   pageSearcher: Fuse<{ link: string, title?: string }>

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,7 @@ import { readPackageJSON } from 'pkg-types'
 import { setupDevToolsUI } from './devtools'
 import { prerender } from './prerender'
 import { crawlFetch } from './runtime/shared/crawl'
+import { serializeFilterEntries } from './runtime/shared/sharedUtils'
 import { convertNuxtPagesToPaths } from './util'
 
 export interface ModuleOptions {
@@ -116,6 +117,19 @@ export interface ModuleOptions {
    */
   enabled: boolean
   /**
+   * Pages to exclude from link checking entirely.
+   *
+   * When a page matches, none of its links will be inspected.
+   *
+   * Supports the same pattern types as `excludeLinks`:
+   * - Exact matches: `/about`
+   * - Wildcards: `/admin/**`
+   * - RegExp patterns: `/^\/blog\/\d+$/`
+   *
+   * @default []
+   */
+  excludePages: (string | RegExp)[]
+  /**
    * Display debug information.
    *
    * @default false
@@ -162,6 +176,7 @@ export default defineNuxtModule<ModuleOptions>({
       excludeLinks: [
         excludeUnderscorePathsRe,
       ],
+      excludePages: [],
       skipInspections: [],
     }
   },
@@ -239,7 +254,8 @@ export default defineNuxtModule<ModuleOptions>({
         version,
         hasSitemapModule,
         rootDir: nuxt.options.rootDir,
-        excludeLinks: config.excludeLinks,
+        excludeLinks: serializeFilterEntries(config.excludeLinks),
+        excludePages: serializeFilterEntries(config.excludePages),
         skipInspections: config.skipInspections,
         fetchTimeout: config.fetchTimeout,
         showLiveInspections: config.showLiveInspections,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -120,11 +120,14 @@ export function prerender(config: ModuleOptions, version?: string, nuxt = useNux
   const urlFilter = createFilter({
     exclude: config.excludeLinks,
   })
+  const pageFilter = createFilter({
+    exclude: config.excludePages,
+  })
   nuxt.hooks.hook('nitro:init', async (nitro) => {
     const siteConfig = useSiteConfig()
     nitro.hooks.hook('prerender:generate', async (ctx) => {
       const route = decodeURI(ctx.route)
-      if (ctx.contents && !ctx.error && ctx.fileName?.endsWith('.html') && !route.endsWith('.html') && urlFilter(route))
+      if (ctx.contents && !ctx.error && ctx.fileName?.endsWith('.html') && !route.endsWith('.html') && pageFilter(route))
         linkMap[route] = await extractPayload(ctx.contents, nuxt.options.app.rootAttrs?.id || '')
 
       setLinkResponse(route, Promise.resolve({
@@ -146,6 +149,7 @@ export function prerender(config: ModuleOptions, version?: string, nuxt = useNux
       nitro.logger.info('Running link inspections...')
       const inspectionCtx = {
         urlFilter,
+        pageFilter,
         config,
         nuxt,
         pageSearcher,

--- a/src/runtime/app/plugins/view/client.ts
+++ b/src/runtime/app/plugins/view/client.ts
@@ -6,7 +6,7 @@ import type { LinkInspectionResult, NuxtLinkCheckerClient } from '../../../types
 import { useRuntimeConfig } from '#imports'
 import { useLocalStorage } from '@vueuse/core'
 import { computed, createApp, h, ref, unref } from 'vue'
-import { createFilter } from '../../../shared/sharedUtils'
+import { createFilter, deserializeFilterEntries } from '../../../shared/sharedUtils'
 import Main from './Main.vue'
 import { linkDb } from './state'
 
@@ -48,7 +48,10 @@ export async function setupLinkCheckerClient({ nuxt, route }: { nuxt: NuxtApp, r
 
   const runtimeConfig = useRuntimeConfig().public['nuxt-link-checker'] || {} as any
   const filter = createFilter({
-    exclude: runtimeConfig.excludeLinks,
+    exclude: deserializeFilterEntries(runtimeConfig.excludeLinks || []),
+  })
+  const pageFilter = createFilter({
+    exclude: deserializeFilterEntries(runtimeConfig.excludePages || []),
   })
 
   const client: NuxtLinkCheckerClient = {
@@ -57,6 +60,8 @@ export async function setupLinkCheckerClient({ nuxt, route }: { nuxt: NuxtApp, r
     scanLinks() {
       elMap = {}
       visibleLinks.clear()
+      if (!pageFilter(route.path))
+        return
       lastIds = [...new Set(Array.from(document.querySelectorAll('#__nuxt [id]'), el => el.id))]
       Array.from(document.querySelectorAll('#__nuxt a'), el => ({ el, link: el.getAttribute('href')! }))
         .forEach(({ el, link }) => {

--- a/src/runtime/shared/sharedUtils.ts
+++ b/src/runtime/shared/sharedUtils.ts
@@ -1,1 +1,25 @@
 export { createFilter, type CreateFilterOptions } from 'nuxtseo-shared/utils'
+
+export interface SerializedRegExp {
+  __regexp__: true
+  source: string
+  flags: string
+}
+
+export type SerializedFilterEntry = string | SerializedRegExp
+
+export function serializeFilterEntries(entries: (string | RegExp)[]): SerializedFilterEntry[] {
+  return entries.map(e =>
+    e instanceof RegExp
+      ? { __regexp__: true as const, source: e.source, flags: e.flags }
+      : e,
+  )
+}
+
+export function deserializeFilterEntries(entries: SerializedFilterEntry[]): (string | RegExp)[] {
+  return entries.map(e =>
+    typeof e === 'object' && e !== null && '__regexp__' in e
+      ? new RegExp(e.source, e.flags)
+      : e as string,
+  )
+}


### PR DESCRIPTION
## Summary

Closes #44

Adds a new `excludePages` configuration option that excludes entire pages from link checking. When a page matches, none of its links will be inspected.

- **Build mode (`nuxt generate` / `nuxt build`):** Pages matching `excludePages` are skipped during HTML extraction in the `prerender:generate` hook, so their links are never collected or inspected.
- **Dev mode (live inspections):** The client plugin checks `pageFilter(route.path)` at the start of `scanLinks()` and returns early for excluded pages, preventing any link scanning or queue work.

Supports the same pattern types as `excludeLinks`: exact strings, wildcards, and RegExp patterns.

```ts
export default defineNuxtConfig({
  linkChecker: {
    excludePages: [
      '/external-links',
      '/embed/**',
      /^\/generated\//,
    ],
  },
})
```

Also includes serialization helpers for RegExp patterns in runtime config (from #61), enabling proper RegExp support across the build/client boundary via `serializeFilterEntries` / `deserializeFilterEntries`.

## Test plan

- [ ] Verify `excludePages` with exact string skips that page during `nuxt generate`
- [ ] Verify wildcard patterns (e.g. `/embed/**`) exclude matching routes
- [ ] Verify RegExp patterns work after serialization/deserialization in dev mode
- [ ] Verify `excludeLinks` still works independently for individual link filtering
- [ ] Verify pages not matching `excludePages` are still fully inspected