### PR TITLE
fix(eslint): normalize trailing slashes in valid-route and valid-sitemap-link

### DIFF
--- a/src/eslint/rules/valid-route.ts
+++ b/src/eslint/rules/valid-route.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint'
 import { createRouteMatcher, createSuggester, loadRoutes } from '../utils/routes'
-import { createCombinedVisitors, stripQueryAndHash } from '../utils/visitors'
+import { createCombinedVisitors, stripQueryAndHash, withoutTrailingSlash } from '../utils/visitors'
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
     if (!routes.staticRoutes.length && !routes.dynamicRoutes.length)
       return {}
 
-    const allStaticSet = new Set(routes.staticRoutes)
+    const allStaticSet = new Set(routes.staticRoutes.map(withoutTrailingSlash))
     const matchDynamic = createRouteMatcher(routes.dynamicRoutes)
     const suggest = createSuggester(routes.staticRoutes)
 
@@ -36,7 +36,7 @@ const rule: Rule.RuleModule = {
       if (!link.startsWith('/'))
         return
 
-      const pathname = stripQueryAndHash(link)
+      const pathname = withoutTrailingSlash(stripQueryAndHash(link))
 
       // Check exact match against static routes
       if (allStaticSet.has(pathname))

--- a/src/eslint/rules/valid-sitemap-link.ts
+++ b/src/eslint/rules/valid-sitemap-link.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint'
 import { createRouteMatcher, createSuggester, loadRoutes } from '../utils/routes'
-import { createCombinedVisitors, stripQueryAndHash } from '../utils/visitors'
+import { createCombinedVisitors, stripQueryAndHash, withoutTrailingSlash } from '../utils/visitors'
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
     if (!routes.staticRoutes.length)
       return {}
 
-    const staticSet = new Set(routes.staticRoutes)
+    const staticSet = new Set(routes.staticRoutes.map(withoutTrailingSlash))
     const matchDynamic = createRouteMatcher(routes.dynamicRoutes)
     const suggest = createSuggester(routes.staticRoutes)
 
@@ -43,7 +43,7 @@ const rule: Rule.RuleModule = {
       if (!link.startsWith('/'))
         return
 
-      const pathname = stripQueryAndHash(link)
+      const pathname = withoutTrailingSlash(stripQueryAndHash(link))
 
       if (staticSet.has(pathname))
         return

--- a/src/eslint/utils/visitors.ts
+++ b/src/eslint/utils/visitors.ts
@@ -51,6 +51,10 @@ export function shouldSkipLink(link: string): boolean {
   return false
 }
 
+export function withoutTrailingSlash(path: string): string {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+}
+
 export function stripQueryAndHash(link: string): string {
   const hashIndex = link.indexOf('#')
   const queryIndex = link.indexOf('?')

--- a/test/unit/eslint/valid-route.test.ts
+++ b/test/unit/eslint/valid-route.test.ts
@@ -43,6 +43,12 @@ describe('valid-route', () => {
         // rel="nofollow" escape hatch
         vueCase('<template><a href="/nonexistent" rel="nofollow" /></template>'),
         vueCase('<template><NuxtLink to="/nonexistent" rel="nofollow" /></template>'),
+        // trailing slash normalization
+        vueCase('<template><NuxtLink to="/about/" /></template>'),
+        vueCase('<template><NuxtLink to="/blog/hello-world/" /></template>'),
+        vueCase('<template><NuxtLink to="/contact/" /></template>'),
+        vueCase('<template><NuxtLink to="/about/?ref=home" /></template>'),
+        vueCase('<template><NuxtLink to="/about/#section" /></template>'),
         // static file extensions (served from public/)
         vueCase('<template><a href="/document.pdf" /></template>'),
         vueCase('<template><a href="/image.png" /></template>'),

--- a/test/unit/eslint/valid-sitemap-link.test.ts
+++ b/test/unit/eslint/valid-sitemap-link.test.ts
@@ -32,6 +32,9 @@ describe('valid-sitemap-link', () => {
         vueCase('<template><NuxtLink to="/blog/hello-world" /></template>'),
         vueCase('<template><a href="https://example.com" /></template>'),
         vueCase('<template><a href="#section" /></template>'),
+        // trailing slash normalization
+        vueCase('<template><NuxtLink to="/about/" /></template>'),
+        vueCase('<template><NuxtLink to="/blog/hello-world/" /></template>'),
       ],
       invalid: [
         // /blog/unknown-slug matches dynamic route /blog/:slug


### PR DESCRIPTION
### 🔗 Linked issue

N/A (reported via Discord)

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `valid-route` and `valid-sitemap-link` ESLint rules used exact string matching when comparing link paths against known routes. When `site.trailingSlash: true` was configured, every link with a trailing slash (e.g. `/about/`) would fail validation because routes are stored without trailing slashes (`/about`).

Both rules now normalize trailing slashes before comparison using a `withoutTrailingSlash` helper, making route matching work regardless of the `trailingSlash` configuration. Tests added for trailing slash variants in both rules.