### PR TITLE
fix(markdown): change return value of preprocess when no links exist

### DIFF
--- a/src/eslint/processor.ts
+++ b/src/eslint/processor.ts
@@ -46,7 +46,7 @@ export const markdownProcessor: Linter.Processor = {
     const links = extractMarkdownLinks(text)
     if (!links.length) {
       lineMapStack.push(new Map())
-      return [{ text, filename: '0.md' }]
+      return []
     }
 
     const virtualLines: string[] = []


### PR DESCRIPTION
### Description

The link-checker/markdown processor is registered for all **/*.md files. Its preprocess() function has two paths:

- Files WITH `[text](url)` links → extracts them as navigateTo('...') JS code with filename "0.js" → valid JS, no parse error
- Files WITHOUT any links → returns [{ text: rawMarkdown, filename: "0.md" }] (the raw markdown unchanged!)

ESLint then tries to parse the raw markdown of "0.md" using the default JS parser (espree), when no markdown parser is configured. This produces parse errors.

I propose that the processor should return [] (empty) instead of [{ text, filename: "0.md" }] for files with no links.

### Linked Issues

none

### Additional context

<img width="530" height="451" alt="image" src="https://github.com/user-attachments/assets/2e5e94ed-4e4a-4e0c-8609-2b7641a7c72a" />

https://github.com/maevsi/vibetype/actions/runs/23872223452/job/69606955871?pr=2241#step:7:556