### PR TITLE
docs: explain automatic exclusion of the "app.baseUrl" from the check

### DIFF
--- a/docs/content/2.guides/2.exclude-links.md
+++ b/docs/content/2.guides/2.exclude-links.md
@@ -7,6 +7,12 @@ Exclude URLs from inspection by adding them to the `excludeLinks` array. This pr
 
 To skip all link checking on certain pages entirely, see [Exclude Pages](/docs/link-checker/guides/exclude-pages).
 
+Note:
+
+If any `app.baseUrl` is defined in the nuxt configuration, then it will be _automatically added_ to the links exclusion list in order to avoid misleading warnings during build due to `<NuxtLink>`{lang="html"} handling of links to `"/"` i.e. to the root of the nuxt app.
+
+Until nuxt-link-checker v5.0.7, `<NuxtLink to:"/">home</NuxtLink>`{lang="html"} and similar were triggering some warning during the app compilation/build. See [Exclude links to the application root](#exclude-links-to-the-application-root) below
+
 ## Pattern Types
 
 Three pattern types are supported. They are evaluated in order: RegExp first, then exact string match, then wildcard.
@@ -124,6 +130,25 @@ export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
       /#.*/, // All hash links
+    ],
+  },
+})
+```
+
+### Exclude links to the application root
+
+** not required anymore when using _nuxt-link-checker version > v5.0.7_ **
+
+To avoid warnings due to `<NuxtLink>`{lang="html"} handling of links to `"/"` (app root aka "home") in case of a configured `app.baseUrl`, the `baseUrl` should be added to the **excludeLinks** list.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  app: {
+    baseUrl: '/nuxt-app-root-path-on-server/'
+  },
+  linkChecker: {
+    excludeLinks: [
+      '/nuxt-app-root-path-on-server/', // exclude baseUrl to avoid warnings
     ],
   },
 })


### PR DESCRIPTION
### Description

document the default exclusion of `app.baseUrl` (when configured) from the links-checking procedure

### Linked Issues

#84 
#85