### PR TITLE
refactor(devtools): NuxtPage child routes + explicit imports + ^5.2.4

### DIFF
--- a/devtools/lib/link-checker/rpc-types.ts
+++ b/devtools/lib/link-checker/rpc-types.ts
@@ -1,2 +1,1 @@
-export type ClientFunctions = any
-export type ServerFunctions = any
+export type { ClientFunctions, ServerFunctions } from '../../../src/rpc-types'

--- a/devtools/lib/link-checker/rpc.ts
+++ b/devtools/lib/link-checker/rpc.ts
@@ -1,7 +1,9 @@
 import type { BirpcReturn } from 'birpc'
 import type { ClientFunctions, ServerFunctions } from './rpc-types'
 import type { NuxtLinkCheckerClient } from './types'
+import { useDevtoolsConnection } from 'nuxtseo-layer-devtools/composables/rpc'
 import { getQuery } from 'ufo'
+import { ref, unref } from 'vue'
 import { linkDb, linkFilter, queueLength, visibleLinks } from './state'
 
 const RPC_NAMESPACE = 'nuxt-link-checker-rpc'

--- a/devtools/lib/link-checker/state.ts
+++ b/devtools/lib/link-checker/state.ts
@@ -1,4 +1,9 @@
 import type { LinkInspectionResult } from './types'
+import { useAsyncData } from '#imports'
+import { useLocalStorage } from '@vueuse/core'
+import { appFetch } from 'nuxtseo-layer-devtools/composables/rpc'
+import { refreshTime } from 'nuxtseo-layer-devtools/composables/state'
+import { computed, ref } from 'vue'
 
 export const linkDb = ref<LinkInspectionResult[]>([])
 export const showLiveInspections = useLocalStorage<boolean>('nuxt-link-checker:show-live-inspections', true)
@@ -6,6 +11,35 @@ export const visibleLinks = ref<string[]>([])
 export const queueLength = ref(0)
 
 export const linkFilter = ref<string | false>('')
+
+// Derived link views shared across the Inspections and Links tabs
+export const nodes = computed(() => {
+  const validLinks = visibleLinks.value
+  let n = [...linkDb.value]
+  if (linkFilter.value)
+    n = n.filter(node => node.link === linkFilter.value)
+  else
+    n = n.filter(node => validLinks.includes(node.link))
+  return n.sort((a, b) => (a.fix && !b.fix ? 1 : -1))
+})
+
+export const failingNodes = computed(() => {
+  const seen = new Set<string>()
+  return nodes.value.filter((n) => {
+    if (!n.error.length && !n.warning.length)
+      return false
+    if (seen.has(n.link))
+      return false
+    seen.add(n.link)
+    return true
+  })
+})
+
+export const internalLinks = computed(() => nodes.value.filter(n => n.passes && n.link.startsWith('/')))
+export const externalLinks = computed(() => nodes.value.filter(n => n.passes && !n.link.startsWith('/')))
+export const errorCount = computed(() => nodes.value.reduce((count, n) => count + n.error.length, 0))
+export const warningCount = computed(() => nodes.value.reduce((count, n) => count + n.warning.length, 0))
+export const visibleLinkCount = computed(() => visibleLinks.value.length)
 
 export function useDebugData(): any {
   return useAsyncData<{ runtimeConfig: any } | null>('link-checker-debug', () => {

--- a/devtools/lib/link-checker/types.ts
+++ b/devtools/lib/link-checker/types.ts
@@ -1,2 +1,1 @@
-export type NuxtLinkCheckerClient = any
-export type LinkInspectionResult = any
+export type { LinkInspectionResult, NuxtLinkCheckerClient } from '../../../src/runtime/types'

--- a/devtools/pages/link-checker.vue
+++ b/devtools/pages/link-checker.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
-import FixActionDialog from '../components/link-checker/FixActionDialog.vue'
+import { navigateTo, useRoute } from '#imports'
+import { loadShiki } from 'nuxtseo-layer-devtools/composables/shiki'
+import { isProductionMode, refreshSources } from 'nuxtseo-layer-devtools/composables/state'
+import { computed, ref, watch } from 'vue'
 import { linkCheckerRpc } from '../lib/link-checker/rpc'
-import {
-  linkDb,
-  linkFilter,
-  queueLength,
-  showLiveInspections,
-  useDebugData,
-  visibleLinks,
-} from '../lib/link-checker/state'
+import { linkDb, queueLength, showLiveInspections, useDebugData } from '../lib/link-checker/state'
 
 await loadShiki({
   extraLangs: [
@@ -18,70 +14,26 @@ await loadShiki({
 
 const { data } = await useDebugData()
 
-const refreshSnippets = ref(0)
-
-onMounted(() => {
-  const timer = setInterval(() => {
-    refreshSnippets.value++
-    if (refreshSnippets.value >= 3)
-      clearInterval(timer)
-  }, 2000)
-
-  onUnmounted(() => {
-    clearInterval(timer)
-  })
+const route = useRoute()
+const currentTab = computed(() => {
+  const p = route.path
+  if (p.startsWith('/link-checker/links'))
+    return 'links'
+  if (p.startsWith('/link-checker/debug'))
+    return 'debug'
+  if (p.startsWith('/link-checker/docs'))
+    return 'docs'
+  return 'inspections'
 })
 
-const nodes = computed(() => {
-  const validLinks = visibleLinks.value
-  let n = [...linkDb.value]
-  if (linkFilter.value)
-    n = n.filter(node => node.link === linkFilter.value)
-  else
-    n = n.filter(node => validLinks.includes(node.link))
-  return n.sort((a, b) => {
-    return a.fix && !b.fix ? 1 : -1
-  })
-})
+const navItems = [
+  { value: 'inspections', to: '/link-checker', icon: 'carbon:warning-diamond', label: 'Inspections', devOnly: false },
+  { value: 'links', to: '/link-checker/links', icon: 'carbon:checkmark-outline', label: 'Links', devOnly: false },
+  { value: 'debug', to: '/link-checker/debug', icon: 'carbon:debug', label: 'Debug', devOnly: true },
+  { value: 'docs', to: '/link-checker/docs', icon: 'carbon:book', label: 'Docs', devOnly: false },
+]
 
-const failingNodes = computed(() => {
-  const seen = new Set<string>()
-  return nodes.value.filter((n) => {
-    if (!n.error.length && !n.warning.length)
-      return false
-    if (seen.has(n.link))
-      return false
-    seen.add(n.link)
-    return true
-  })
-})
-
-const internalLinks = computed(() => nodes.value.filter(n => n.passes && n.link.startsWith('/')))
-const externalLinks = computed(() => nodes.value.filter(n => n.passes && !n.link.startsWith('/')))
-
-const errorCount = computed(() => {
-  return nodes.value.reduce((count, n) => count + n.error.length, 0)
-})
-const warningCount = computed(() => {
-  return nodes.value.reduce((count, n) => count + n.warning.length, 0)
-})
-
-const visibleLinkCount = computed(() => {
-  return visibleLinks.value.length
-})
-
-const runtimeConfigItems = computed(() => {
-  const config = data.value?.runtimeConfig || {}
-  return Object.entries(config)
-    .filter(([key]) => key !== 'version')
-    .map(([key, value]) => ({
-      key,
-      value: typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value ?? ''),
-      mono: true,
-      copyable: true,
-      code: typeof value === 'object' ? 'json' as const : undefined,
-    }))
-})
+const loading = ref(false)
 
 async function retryAll() {
   linkDb.value = []
@@ -92,17 +44,6 @@ async function toggleLiveInspections() {
   showLiveInspections.value = !showLiveInspections.value
   await linkCheckerRpc.value!.toggleLiveInspections(showLiveInspections.value)
 }
-
-const tab = ref('inspections')
-const loading = ref(false)
-
-const navItems = [
-  { value: 'inspections', icon: 'carbon:warning-diamond', label: 'Inspections', devOnly: false },
-  { value: 'links', icon: 'carbon:checkmark-outline', label: 'Links', devOnly: false },
-  { value: 'debug', icon: 'carbon:debug', label: 'Debug', devOnly: true },
-  { value: 'docs', icon: 'carbon:book', label: 'Docs', devOnly: false },
-]
-
 async function refresh() {
   loading.value = true
   await retryAll()
@@ -111,11 +52,17 @@ async function refresh() {
     loading.value = false
   }, 300)
 }
+
+// Debug data is dev-only; leave the debug tab when the header switches to Production
+watch(isProductionMode, (isProd) => {
+  if (isProd && currentTab.value === 'debug')
+    return navigateTo('/link-checker')
+})
 </script>
 
 <template>
   <DevtoolsLayout
-    v-model:active-tab="tab"
+    v-model:active-tab="currentTab"
     module-name="nuxt-link-checker"
     title="Link Checker"
     icon="carbon:cloud-satellite-link"
@@ -134,87 +81,6 @@ async function refresh() {
         @click="toggleLiveInspections"
       />
     </template>
-
-    <!-- Inspections tab -->
-    <div v-if="tab === 'inspections'" class="space-y-2">
-      <DevtoolsToolbar>
-        <DevtoolsMetric
-          v-if="queueLength"
-          icon="carbon:progress-bar-round"
-          :value="`${visibleLinkCount ? Math.round((Math.abs(queueLength - visibleLinkCount) / visibleLinkCount) * 100) : 0}%`"
-        />
-        <DevtoolsMetric
-          v-if="errorCount"
-          icon="carbon:error"
-          :value="errorCount"
-          label="Errors"
-          variant="danger"
-        />
-        <DevtoolsMetric
-          v-if="warningCount"
-          icon="carbon:warning"
-          :value="warningCount"
-          label="Warnings"
-          variant="warning"
-        />
-        <DevtoolsMetric
-          v-if="!warningCount && !errorCount"
-          icon="carbon:checkmark-outline"
-          value="All links passing"
-          variant="success"
-        />
-      </DevtoolsToolbar>
-
-      <p v-if="linkFilter" class="text-sm flex items-center gap-1 mb-4">
-        <UIcon name="carbon:filter" />
-        Filtering Results.
-        <button type="button" class="underline" @click="linkFilter = false">
-          Show All
-        </button>
-      </p>
-
-      <div v-if="!linkFilter">
-        <template v-if="failingNodes.length">
-          <LinkInspection
-            v-for="(item, index) of failingNodes"
-            :key="index"
-            :item="item"
-            class="odd:bg-[var(--color-bg-elevated)] p-2"
-          />
-        </template>
-        <DevtoolsEmptyState
-          v-else-if="!queueLength"
-          icon="carbon:checkmark-outline"
-          title="No issues found"
-          description="All visible links are passing validation."
-        />
-      </div>
-      <div v-else>
-        <LinkInspection v-for="(item, index) of nodes" :key="index" :item="item" />
-      </div>
-      <FixActionDialog />
-    </div>
-
-    <!-- Links tab -->
-    <div v-else-if="tab === 'links'" class="space-y-4">
-      <DevtoolsSection icon="carbon:chart-network" text="Internal Links">
-        <LinkPassing v-for="(item, index) of internalLinks" :key="index" :item="item" />
-        <DevtoolsEmptyState v-if="!internalLinks.length" icon="carbon:link" title="No internal links" />
-      </DevtoolsSection>
-      <DevtoolsSection icon="carbon:launch" text="External Links">
-        <LinkPassing v-for="(item, index) of externalLinks" :key="index" :item="item" />
-        <DevtoolsEmptyState v-if="!externalLinks.length" icon="carbon:link" title="No external links" />
-      </DevtoolsSection>
-    </div>
-
-    <!-- Debug tab -->
-    <div v-else-if="tab === 'debug'" class="space-y-4">
-      <DevtoolsSection icon="carbon:settings" text="Runtime Config">
-        <DevtoolsKeyValue :items="runtimeConfigItems" striped />
-      </DevtoolsSection>
-    </div>
-
-    <!-- Docs tab -->
-    <DevtoolsDocs v-else-if="tab === 'docs'" url="https://nuxtseo.com/link-checker" />
+    <NuxtPage />
   </DevtoolsLayout>
 </template>

--- a/devtools/pages/link-checker/debug.vue
+++ b/devtools/pages/link-checker/debug.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDebugData } from '../../lib/link-checker/state'
+
+const { data } = useDebugData()
+
+const runtimeConfigItems = computed(() => {
+  const config = data.value?.runtimeConfig || {}
+  return Object.entries(config)
+    .filter(([key]) => key !== 'version')
+    .map(([key, value]) => ({
+      key,
+      value: typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value ?? ''),
+      mono: true,
+      copyable: true,
+      code: typeof value === 'object' ? 'json' as const : undefined,
+    }))
+})
+</script>
+
+<template>
+  <DevtoolsSection icon="carbon:settings" text="Runtime Config">
+    <DevtoolsKeyValue :items="runtimeConfigItems" striped />
+  </DevtoolsSection>
+</template>

--- a/devtools/pages/link-checker/docs.vue
+++ b/devtools/pages/link-checker/docs.vue
@@ -1,0 +1,3 @@
+<template>
+  <DevtoolsDocs url="https://nuxtseo.com/link-checker" />
+</template>

--- a/devtools/pages/link-checker/index.vue
+++ b/devtools/pages/link-checker/index.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import FixActionDialog from '../../components/link-checker/FixActionDialog.vue'
+import {
+  errorCount,
+  failingNodes,
+  linkFilter,
+  nodes,
+  queueLength,
+  visibleLinkCount,
+  warningCount,
+} from '../../lib/link-checker/state'
+</script>
+
+<template>
+  <div class="space-y-2">
+    <DevtoolsToolbar>
+      <DevtoolsMetric
+        v-if="queueLength"
+        icon="carbon:progress-bar-round"
+        :value="`${visibleLinkCount ? Math.round((Math.abs(queueLength - visibleLinkCount) / visibleLinkCount) * 100) : 0}%`"
+      />
+      <DevtoolsMetric
+        v-if="errorCount"
+        icon="carbon:error"
+        :value="errorCount"
+        label="Errors"
+        variant="danger"
+      />
+      <DevtoolsMetric
+        v-if="warningCount"
+        icon="carbon:warning"
+        :value="warningCount"
+        label="Warnings"
+        variant="warning"
+      />
+      <DevtoolsMetric
+        v-if="!warningCount && !errorCount"
+        icon="carbon:checkmark-outline"
+        value="All links passing"
+        variant="success"
+      />
+    </DevtoolsToolbar>
+
+    <p v-if="linkFilter" class="text-sm flex items-center gap-1 mb-4">
+      <UIcon name="carbon:filter" />
+      Filtering Results.
+      <button type="button" class="underline" @click="linkFilter = false">
+        Show All
+      </button>
+    </p>
+
+    <div v-if="!linkFilter">
+      <template v-if="failingNodes.length">
+        <LinkInspection
+          v-for="(item, index) of failingNodes"
+          :key="index"
+          :item="item"
+          class="odd:bg-[var(--color-bg-elevated)] p-2"
+        />
+      </template>
+      <DevtoolsEmptyState
+        v-else-if="!queueLength"
+        icon="carbon:checkmark-outline"
+        title="No issues found"
+        description="All visible links are passing validation."
+      />
+    </div>
+    <div v-else>
+      <LinkInspection v-for="(item, index) of nodes" :key="index" :item="item" />
+    </div>
+    <FixActionDialog />
+  </div>
+</template>

--- a/devtools/pages/link-checker/links.vue
+++ b/devtools/pages/link-checker/links.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { externalLinks, internalLinks } from '../../lib/link-checker/state'
+</script>
+
+<template>
+  <div class="space-y-4">
+    <DevtoolsSection icon="carbon:chart-network" text="Internal Links">
+      <LinkPassing v-for="(item, index) of internalLinks" :key="index" :item="item" />
+      <DevtoolsEmptyState v-if="!internalLinks.length" icon="carbon:link" title="No internal links" />
+    </DevtoolsSection>
+    <DevtoolsSection icon="carbon:launch" text="External Links">
+      <LinkPassing v-for="(item, index) of externalLinks" :key="index" :item="item" />
+      <DevtoolsEmptyState v-if="!externalLinks.length" icon="carbon:link" title="No external links" />
+    </DevtoolsSection>
+  </div>
+</template>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "client:build": "node -e \"require('fs').cpSync('devtools','dist/devtools',{recursive:true})\"",
     "build": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt-module-build build && npm run client:build",
     "dev": "nuxi dev playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground && pnpm run client:build",
     "prepack": "pnpm run build",
     "release": "pnpm build && bumpp --output=CHANGELOG.md",
     "lint": "eslint .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,11 +70,11 @@ catalogs:
       specifier: ^4.0.8
       version: 4.0.8
     nuxtseo-layer-devtools:
-      specifier: ^5.2.4
-      version: 5.2.4
+      specifier: ^5.2.5
+      version: 5.2.5
     nuxtseo-shared:
-      specifier: ^5.2.4
-      version: 5.2.4
+      specifier: ^5.2.5
+      version: 5.2.5
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -148,7 +148,7 @@ importers:
         version: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))(zod@3.25.76)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
+        version: 5.2.5(0709e006cc24e03bdb9d7c957f464423)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -215,7 +215,7 @@ importers:
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3)
       nuxtseo-layer-devtools:
         specifier: 'catalog:'
-        version: 5.2.4(dcb4ad5ad976c661a2c1c6dd0d0dcac2)
+        version: 5.2.5(dcb4ad5ad976c661a2c1c6dd0d0dcac2)
       sirv:
         specifier: 'catalog:'
         version: 3.0.2
@@ -5612,11 +5612,11 @@ packages:
       '@types/node':
         optional: true
 
-  nuxtseo-layer-devtools@5.2.4:
-    resolution: {integrity: sha512-L826Gc+TpvWgUN9eZg2thz368sSuhP4LppXNUgKKMz8uMIw7guEtnTEZfWqB9ESf0OTLPOhofkVQRndbFpKd2w==}
+  nuxtseo-layer-devtools@5.2.5:
+    resolution: {integrity: sha512-qKV2oUfH+NgZHTGfhGPv9vDFnhay6wtdmH468am5zi3etP4B4sA2SS3TLTHcraZ6+LKofLAIZS7m4Ny3EOJdKg==}
 
-  nuxtseo-shared@5.2.4:
-    resolution: {integrity: sha512-BGlPZcj3brZxeNrfWZpiiECJDj5Jh8x8UR+f1BuXWgJ14xAnHca0QsBm/dZ1tqrw4HkvJGA9C5pvyrdQ7CRtDw==}
+  nuxtseo-shared@5.2.5:
+    resolution: {integrity: sha512-ZE/daHUgOGzxfPNLPK/BE07itpInUuWDi+70Ut1nCtuMqsGEJer7X51oYDdMW3E75Gazjkfb8PkYcHwNhp3uiw==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0
       nuxt: ^3.16.0 || ^4.0.0
@@ -9205,7 +9205,7 @@ snapshots:
       defu: 6.1.7
       fast-xml-parser: 5.7.2
       nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))(zod@3.25.76)
-      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.5(0709e006cc24e03bdb9d7c957f464423)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13770,7 +13770,7 @@ snapshots:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.2))
-      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.5(0709e006cc24e03bdb9d7c957f464423)
       pathe: 2.0.3
       pkg-types: 2.3.0
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.2))
@@ -13911,7 +13911,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@5.2.4(dcb4ad5ad976c661a2c1c6dd0d0dcac2):
+  nuxtseo-layer-devtools@5.2.5(dcb4ad5ad976c661a2c1c6dd0d0dcac2):
     dependencies:
       '@iconify-json/carbon': 1.2.23
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))
@@ -13921,7 +13921,7 @@ snapshots:
       '@shikijs/themes': 4.2.0
       '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.2))
       '@vueuse/nuxt': 14.3.0(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))
-      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.5(0709e006cc24e03bdb9d7c957f464423)
       ofetch: 1.5.1
       shiki: 4.2.0
       tailwindcss: 4.3.0
@@ -13982,7 +13982,7 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@5.2.4(0709e006cc24e03bdb9d7c957f464423):
+  nuxtseo-shared@5.2.5(0709e006cc24e03bdb9d7c957f464423):
     dependencies:
       '@clack/prompts': 1.5.1
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,11 +70,11 @@ catalogs:
       specifier: ^4.0.8
       version: 4.0.8
     nuxtseo-layer-devtools:
-      specifier: ^5.2.0
-      version: 5.2.0
+      specifier: ^5.2.4
+      version: 5.2.4
     nuxtseo-shared:
-      specifier: ^5.2.0
-      version: 5.2.0
+      specifier: ^5.2.4
+      version: 5.2.4
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -148,7 +148,7 @@ importers:
         version: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))(zod@3.25.76)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.2.0(0709e006cc24e03bdb9d7c957f464423)
+        version: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -215,7 +215,7 @@ importers:
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3)
       nuxtseo-layer-devtools:
         specifier: 'catalog:'
-        version: 5.2.0(dcb4ad5ad976c661a2c1c6dd0d0dcac2)
+        version: 5.2.4(dcb4ad5ad976c661a2c1c6dd0d0dcac2)
       sirv:
         specifier: 'catalog:'
         version: 3.0.2
@@ -5612,11 +5612,11 @@ packages:
       '@types/node':
         optional: true
 
-  nuxtseo-layer-devtools@5.2.0:
-    resolution: {integrity: sha512-ltBWdt5wUxCBXN25EJMyHNYGl+1BZGA/y4w9vy0Zpemy7U3K6Vtoszy2tnp61nD15MXtv5zMDlXbsQVHS48IvQ==}
+  nuxtseo-layer-devtools@5.2.4:
+    resolution: {integrity: sha512-L826Gc+TpvWgUN9eZg2thz368sSuhP4LppXNUgKKMz8uMIw7guEtnTEZfWqB9ESf0OTLPOhofkVQRndbFpKd2w==}
 
-  nuxtseo-shared@5.2.0:
-    resolution: {integrity: sha512-lnS8XyI4DhXKXe4sHXPVV1MY49dkCrjgtIKbyO2VZegzy1VvBegaa39Rm7hwa/pn9bHjIyNPismTouxWCz980w==}
+  nuxtseo-shared@5.2.4:
+    resolution: {integrity: sha512-BGlPZcj3brZxeNrfWZpiiECJDj5Jh8x8UR+f1BuXWgJ14xAnHca0QsBm/dZ1tqrw4HkvJGA9C5pvyrdQ7CRtDw==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0
       nuxt: ^3.16.0 || ^4.0.0
@@ -6633,9 +6633,6 @@ packages:
       tailwind-merge:
         optional: true
 
-  tailwindcss@4.2.2:
-    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
-
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -7537,9 +7534,9 @@ snapshots:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.2.1(jiti@2.6.1))
       '@eslint/markdown': 8.0.1
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.2.1(jiti@2.6.1))
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/parser': 8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
-      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.5(@types/node@24.6.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))
+      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.5(@types/node@24.6.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))
       ansis: 4.2.0
       cac: 7.0.0
       eslint: 10.2.1(jiti@2.6.1)
@@ -7558,7 +7555,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-toml: 1.3.1(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-unicorn: 64.0.0(eslint@10.2.1(jiti@2.6.1))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@10.2.1(jiti@2.6.1)))(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@10.2.1(jiti@2.6.1)))
       eslint-plugin-yml: 3.3.1(eslint@10.2.1(jiti@2.6.1))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.33)(eslint@10.2.1(jiti@2.6.1))
@@ -8967,7 +8964,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.8.2(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(focus-trap@7.6.6)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.2)))(vue@3.5.33(typescript@6.0.2))(yjs@13.6.30)(zod@3.25.76)':
+  '@nuxt/ui@4.8.2(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(focus-trap@7.6.6)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.3.0)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.2)))(vue@3.5.33(typescript@6.0.2))(yjs@13.6.30)(zod@3.25.76)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.2))
@@ -9023,8 +9020,8 @@ snapshots:
       reka-ui: 2.9.9(vue@3.5.33(typescript@6.0.2))
       scule: 1.3.0
       tailwind-merge: 3.6.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.2.2)
-      tailwindcss: 4.2.2
+      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
+      tailwindcss: 4.3.0
       tinyglobby: 0.2.17
       typescript: 6.0.2
       ufo: 1.6.4
@@ -9147,7 +9144,7 @@ snapshots:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       pathe: 1.1.2
       pkg-types: 1.3.1
-      semver: 7.7.4
+      semver: 7.8.3
     transitivePeerDependencies:
       - magicast
 
@@ -9208,7 +9205,7 @@ snapshots:
       defu: 6.1.7
       fast-xml-parser: 5.7.2
       nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))(zod@3.25.76)
-      nuxtseo-shared: 5.2.0(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -9513,7 +9510,7 @@ snapshots:
       '@pnpm/logger': 1001.0.1
       '@pnpm/semver.peer-range': 1000.0.0
       '@pnpm/types': 1001.3.0
-      semver: 7.7.4
+      semver: 7.8.3
 
   '@pnpm/read-project-manifest@1001.2.6(@pnpm/logger@1001.0.1)':
     dependencies:
@@ -9534,7 +9531,7 @@ snapshots:
 
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.3
 
   '@pnpm/text.comments-parser@1000.0.0':
     dependencies:
@@ -9849,7 +9846,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.23.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -10229,10 +10226,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/type-utils': 8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
@@ -10296,7 +10293,7 @@ snapshots:
       eslint: 10.2.1(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      semver: 7.7.4
+      semver: 7.8.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10641,13 +10638,13 @@ snapshots:
       vite: 7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@6.0.2)
 
-  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.5(@types/node@24.6.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))':
+  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.5(@types/node@24.6.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.2.1(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
       typescript: 6.0.2
       vitest: 4.1.5(@types/node@24.6.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))
     transitivePeerDependencies:
@@ -10941,7 +10938,7 @@ snapshots:
       '@nuxt/kit': 4.4.8(magicast@0.5.2)
       '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.2))
       '@vueuse/metadata': 14.3.0
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3)
       vue: 3.5.33(typescript@6.0.2)
     transitivePeerDependencies:
@@ -12018,11 +12015,11 @@ snapshots:
       semver: 7.7.4
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
       eslint: 10.2.1(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2)
 
   eslint-plugin-vue@10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@10.2.1(jiti@2.6.1)))(@typescript-eslint/parser@8.57.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.1(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@10.2.1(jiti@2.6.1))):
     dependencies:
@@ -12330,7 +12327,7 @@ snapshots:
       defu: 6.1.7
       esbuild: 0.27.7
       fontaine: 0.8.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       ohash: 2.0.11
@@ -13058,7 +13055,7 @@ snapshots:
   local-pkg@1.2.1:
     dependencies:
       mlly: 1.8.2
-      pkg-types: 2.3.0
+      pkg-types: 2.3.1
       quansync: 0.2.11
 
   locate-path@6.0.0:
@@ -13773,7 +13770,7 @@ snapshots:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.2))
-      nuxtseo-shared: 5.2.0(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
       pathe: 2.0.3
       pkg-types: 2.3.0
       site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.2))
@@ -13914,20 +13911,20 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@5.2.0(dcb4ad5ad976c661a2c1c6dd0d0dcac2):
+  nuxtseo-layer-devtools@5.2.4(dcb4ad5ad976c661a2c1c6dd0d0dcac2):
     dependencies:
       '@iconify-json/carbon': 1.2.23
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))
       '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@nuxt/ui': 4.8.2(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(focus-trap@7.6.6)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.2)))(vue@3.5.33(typescript@6.0.2))(yjs@13.6.30)(zod@3.25.76)
+      '@nuxt/ui': 4.8.2(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(focus-trap@7.6.6)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.3.0)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.2)))(vue@3.5.33(typescript@6.0.2))(yjs@13.6.30)(zod@3.25.76)
       '@shikijs/langs': 4.2.0
       '@shikijs/themes': 4.2.0
       '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.2))
       '@vueuse/nuxt': 14.3.0(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@types/node@24.6.2)(@vitejs/devtools@0.1.13(@pnpm/logger@1001.0.1)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)))(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.1(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@6.0.2))(yaml@2.8.3))(vue@3.5.33(typescript@6.0.2))
-      nuxtseo-shared: 5.2.0(0709e006cc24e03bdb9d7c957f464423)
+      nuxtseo-shared: 5.2.4(0709e006cc24e03bdb9d7c957f464423)
       ofetch: 1.5.1
       shiki: 4.2.0
-      tailwindcss: 4.2.2
+      tailwindcss: 4.3.0
       ufo: 1.6.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -13985,7 +13982,7 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@5.2.0(0709e006cc24e03bdb9d7c957f464423):
+  nuxtseo-shared@5.2.4(0709e006cc24e03bdb9d7c957f464423):
     dependencies:
       '@clack/prompts': 1.5.1
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.1(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))
@@ -15218,13 +15215,11 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.2.2):
+  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0):
     dependencies:
-      tailwindcss: 4.2.2
+      tailwindcss: 4.3.0
     optionalDependencies:
       tailwind-merge: 3.6.0
-
-  tailwindcss@4.2.2: {}
 
   tailwindcss@4.3.0: {}
 
@@ -15548,7 +15543,7 @@ snapshots:
 
   unplugin-auto-import@21.0.0(@nuxt/kit@4.4.8(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.2))):
     dependencies:
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string: 0.30.21
       picomatch: 4.0.4
       unimport: 5.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,8 +30,8 @@ catalog:
   magic-string: ^0.30.21
   nuxt: ^4.4.2
   nuxt-site-config: ^4.0.8
-  nuxtseo-layer-devtools: ^5.2.4
-  nuxtseo-shared: ^5.2.4
+  nuxtseo-layer-devtools: ^5.2.5
+  nuxtseo-shared: ^5.2.5
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+minimumReleaseAgeExclude:
+  - nuxtseo-layer-devtools
+  - nuxtseo-shared
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -27,8 +30,8 @@ catalog:
   magic-string: ^0.30.21
   nuxt: ^4.4.2
   nuxt-site-config: ^4.0.8
-  nuxtseo-layer-devtools: ^5.2.0
-  nuxtseo-shared: ^5.2.0
+  nuxtseo-layer-devtools: ^5.2.4
+  nuxtseo-shared: ^5.2.4
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "./.nuxt/tsconfig.json",
-  "exclude": ["playground", "test", "devtools", "examples"]
+  "exclude": ["dist", "playground", "test", "devtools", "examples"]
 }


### PR DESCRIPTION
Part of a cross-module devtools parity pass.

## Changes
- **structure**: split the monolithic `pages/link-checker.vue` (inline `v-if` tabs) into a `DevtoolsLayout` shell + `pages/link-checker/{index,links,debug,docs}.vue` child routes
- lift shared link computeds (`nodes`, `failingNodes`, `internalLinks`, `externalLinks`, counts) into `lib/link-checker/state.ts`
- explicit `nuxtseo-layer-devtools/composables/*` imports; `isProductionMode` redirect for the debug tab
- real `ServerFunctions`/`ClientFunctions`/`LinkInspectionResult`/`NuxtLinkCheckerClient` types (were `any`)
- tsconfig: exclude `dist`; bump layer -> `^5.2.4`

The live-RPC mirror (`host.inject('linkChecker')`) and `CodeDiff`/`CodeHighlight` (wrappers over `OCodeBlock`) are intentionally kept.

## Verification
Assembled client compiles; all 5 routes prerender; all 4 tabs render in-browser with 0 JS errors (verified).