### PR TITLE
docs: content audit sweep (grammar, links, structure)

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -1,8 +1,15 @@
 ---
-title: 'Nuxt Link Checker'
-description: 'Find and magically fix links that may be negatively affecting your Nuxt sites SEO.'
+title: Nuxt Link Checker
+description: Find and magically fix links that may be negatively affecting your Nuxt site's SEO.
 navigation:
-  title: 'Introduction'
+  title: Introduction
+relatedPages:
+  - path: /docs/link-checker/getting-started/installation
+    title: Install Nuxt Link Checker
+  - path: /docs/sitemap/getting-started/installation
+    title: Nuxt Sitemap
+  - path: /learn-seo/nuxt/controlling-crawlers
+    title: Controlling Web Crawlers
 ---
 
 ## Why use Nuxt Link Checker?
@@ -23,3 +30,7 @@ Ready to get started? Check out the [installation guide](/docs/link-checker/gett
 - ✨ See live inspections right in your Nuxt App
 - 🧙 Magically fix them in Nuxt Dev Tools
 - 🚩 Generate reports on build (HTML, Markdown, JSON)
+
+::callout{icon="i-heroicons-document-chart-bar" to="/tools/xml-sitemap-validator"}
+**Cross-check your sitemap** - Use our [XML Sitemap Validator](/tools/xml-sitemap-validator) to cross-reference broken links with your sitemap.
+::

--- a/docs/content/0.getting-started/1.installation.md
+++ b/docs/content/0.getting-started/1.installation.md
@@ -1,8 +1,15 @@
 ---
-title: 'Install Nuxt Link Checker'
-description: 'Get started with Nuxt Link Checker by installing the dependency to your project.'
+title: Install Nuxt Link Checker
+description: Get started with Nuxt Link Checker by installing the dependency to your project.
 navigation:
-  title: 'Installation'
+  title: Installation
+relatedPages:
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/link-checker/guides/live-inspections
+    title: Link Checker DevTools
+  - path: /docs/sitemap/getting-started/installation
+    title: Nuxt Sitemap
 ---
 
 ## Setup Module
@@ -18,10 +25,10 @@ npx skilld add nuxt-link-checker
 
 ## Verifying Installation
 
-Nuxt Link Checker provides a visualize integration in development through the Link Checker DevTools tab. Open up DevTools in your Nuxt site and navigate to the `Link Checker` tab
+Nuxt Link Checker provides a visual integration in development through the Link Checker DevTools tab. Open up DevTools in your Nuxt site and navigate to the `Link Checker` tab
 to see live inspections of your links. See the [Link Checker DevTools](/docs/link-checker/guides/live-inspections) guide for more information.
 
-When building your site, the module will check links of all prerendered pages, it's recommended to prerender any pages
+When building your site, the module will check links of all prerendered pages. It's recommended to prerender any pages
 that you'd like to have the links checked on.
 
 ## Next Steps

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -1,11 +1,18 @@
 ---
-title: "Troubleshooting Nuxt Link Checker"
+title: Troubleshooting Nuxt Link Checker
 description: Solve common link checking issues and create reproductions for bug reports.
 navigation:
-  title: "Troubleshooting"
+  title: Troubleshooting
+relatedPages:
+  - path: /docs/link-checker/guides/exclude-links
+    title: Exclude Links
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/nuxt-seo/getting-started/troubleshooting
+    title: Nuxt SEO Troubleshooting
 ---
 
-## Common Issues
+## Debugging
 
 ### Link Detection Issues
 
@@ -33,7 +40,7 @@ If your CI is failing:
 2. Use `failOnError: false` temporarily while fixing issues
 3. Consider using `skipInspections` for rules causing false positives
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     failOnError: false, // Temporarily disable to unblock builds
@@ -49,11 +56,6 @@ If live inspections aren't appearing:
 2. Enable `showLiveInspections` in your config (it is `false` by default)
 3. Restart your dev server after config changes
 
-## Debugging Tools
-
-- [Meta Tag Checker](/tools/meta-tag-checker) - Verify page metadata after fixing broken links
-- [XML Sitemap Validator](/tools/xml-sitemap-validator) - Cross-reference broken links with your sitemap
-
 ## Submitting an Issue
 
 When submitting an issue, it's important to provide as much information as possible.
@@ -61,3 +63,8 @@ When submitting an issue, it's important to provide as much information as possi
 The easiest way to do this is to create a minimal reproduction using the [StackBlitz](https://stackblitz.com) playgrounds:
 
 - [Basic](https://stackblitz.com/edit/nuxt-starter-r2wzt1?file=nuxt.config.ts)
+
+## Debugging Tools
+
+- [Meta Tag Checker](/tools/meta-tag-checker) - Verify page metadata after fixing broken links
+- [XML Sitemap Validator](/tools/xml-sitemap-validator) - Cross-reference broken links with your sitemap

--- a/docs/content/2.guides/0.rules.md
+++ b/docs/content/2.guides/0.rules.md
@@ -1,6 +1,13 @@
 ---
 title: Inspection Rules
 description: Find out what rules are run when checking your links and why they exist.
+relatedPages:
+  - path: /docs/link-checker/guides/exclude-links
+    title: Exclude Links
+  - path: /docs/link-checker/api/config
+    title: Config
+  - path: /docs/robots/getting-started/introduction
+    title: Nuxt Robots
 ---
 
 The module runs 15 inspections covering broken links, SEO best practices, and accessibility. To disable any rule, add it to `skipInspections` in your config.
@@ -252,7 +259,7 @@ export default defineNuxtConfig({
 
 Checks for JavaScript links.
 
-JavaScript links provide poor user experience as they override the default browser behaviour.
+JavaScript links provide poor user experience as they override the default browser behavior.
 
 It's recommended to use a `<button type="button">`{lang="html"} if you need an on click event.
 

--- a/docs/content/2.guides/1.live-inspections.md
+++ b/docs/content/2.guides/1.live-inspections.md
@@ -1,6 +1,13 @@
 ---
 title: Link Checker DevTools
 description: See link validation errors in real-time during development with Nuxt DevTools integration.
+relatedPages:
+  - path: /docs/link-checker/getting-started/installation
+    title: Install Nuxt Link Checker
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/nuxt-seo/guides/debugging-modules
+    title: Debugging Modules
 ---
 
 ::note

--- a/docs/content/2.guides/2.build-scans.md
+++ b/docs/content/2.guides/2.build-scans.md
@@ -10,8 +10,6 @@ relatedPages:
     title: Nuxt Sitemap
 ---
 
-## Introduction
-
 By default, links will be scanned when you run your build.
 
 ## Throwing Build Errors
@@ -28,8 +26,6 @@ export default defineNuxtConfig({
   },
 })
 ```
-
-## Generating Reports
 
 Check the [Generate Reports](/docs/link-checker/guides/generating-reports) guide for more details.
 

--- a/docs/content/2.guides/2.build-scans.md
+++ b/docs/content/2.guides/2.build-scans.md
@@ -1,6 +1,13 @@
 ---
 title: Checking Links on Build
 description: Configure link checking during Nuxt build process and CI integration.
+relatedPages:
+  - path: /docs/link-checker/guides/generating-reports
+    title: Generate Reports
+  - path: /docs/link-checker/api/config
+    title: Config
+  - path: /docs/sitemap/getting-started/installation
+    title: Nuxt Sitemap
 ---
 
 ## Introduction
@@ -14,7 +21,7 @@ the scanner finds broken links.
 
 To do so you can enable the `failOnError` option. This will exit the process with a non-zero exit code.
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     failOnError: true,
@@ -30,7 +37,7 @@ Check the [Generate Reports](/docs/link-checker/guides/generating-reports) guide
 
 If you want to disable build link scanning, you can set `runOnBuild` to `false` in your `nuxt.config`:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     runOnBuild: false,

--- a/docs/content/2.guides/3.exclude-links.md
+++ b/docs/content/2.guides/3.exclude-links.md
@@ -1,6 +1,13 @@
 ---
 title: Exclude Links
 description: Exclude links from being checked by the Nuxt Link Checker.
+relatedPages:
+  - path: /docs/link-checker/guides/exclude-pages
+    title: Exclude Pages
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/site-config/getting-started/introduction
+    title: Nuxt Site Config
 ---
 
 Exclude URLs from inspection by adding them to the `excludeLinks` array. This prevents specific links from being checked on **any** page where they appear.
@@ -16,7 +23,7 @@ The following patterns are excluded by default:
 
 If the Nuxt configuration defines `app.baseUrl`, nuxt-link-checker _automatically adds_ it to the link exclusion list to avoid misleading build warnings from `<NuxtLink>`{lang="html"} handling links to `"/"` i.e. the root of the Nuxt app.
 
-Until nuxt-link-checker v5.0.7, `<NuxtLink to:"/">home</NuxtLink>`{lang="html"} and similar were triggering some warning during the app compilation/build. See [Exclude links to the application root](#exclude-links-to-the-application-root) below.
+Until nuxt-link-checker v5.0.7, `<NuxtLink to="/">home</NuxtLink>`{lang="html"} and similar were triggering some warning during the app compilation/build. See [Exclude links to the application root](#exclude-links-to-the-application-root) below.
 
 ## Pattern Types
 
@@ -24,7 +31,7 @@ Nuxt Link Checker supports three pattern types and evaluates them in order: RegE
 
 ### Exact Matches
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -39,7 +46,7 @@ export default defineNuxtConfig({
 
 Uses [radix3](https://github.com/unjs/radix3) route matching. `*` matches a single path segment, `**` matches any number of segments.
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -51,7 +58,7 @@ export default defineNuxtConfig({
 })
 ```
 
-::callout{type="warning"}
+::warning
 Wildcard patterns use route matching, not glob matching. `/_nuxt/file_*.pdf` will **not** work because `*` only matches full path segments. Use a RegExp pattern instead for partial segment matching.
 ::
 
@@ -59,7 +66,7 @@ Wildcard patterns use route matching, not glob matching. `/_nuxt/file_*.pdf` wil
 
 For advanced matching (partial segments, file extensions, numeric patterns), use RegExp:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -73,7 +80,7 @@ export default defineNuxtConfig({
 
 ### External Links
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -90,7 +97,7 @@ export default defineNuxtConfig({
 
 When importing assets with `?url`, [Vite](https://vite.dev) generates hashed filenames that trigger false positives. Use a RegExp to match them:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -104,7 +111,7 @@ export default defineNuxtConfig({
 
 If you have dynamic routes that aren't prerendered:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -117,7 +124,7 @@ export default defineNuxtConfig({
 
 ### Exclude Auth-Protected Routes
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -130,7 +137,7 @@ export default defineNuxtConfig({
 
 ### Exclude Hash Links
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludeLinks: [
@@ -142,7 +149,7 @@ export default defineNuxtConfig({
 
 ### Exclude links to the application root
 
-** not required anymore when using _nuxt-link-checker version > v5.0.7_ **
+**Not required anymore when using _nuxt-link-checker version > v5.0.7_**
 
 To avoid warnings due to `<NuxtLink>`{lang="html"} handling of links to `"/"` (app root aka "home") with a configured `app.baseUrl`, add the `baseUrl` to the **excludeLinks** list.
 

--- a/docs/content/2.guides/4.exclude-pages.md
+++ b/docs/content/2.guides/4.exclude-pages.md
@@ -1,6 +1,13 @@
 ---
 title: Exclude Pages
 description: Exclude entire pages from link checking.
+relatedPages:
+  - path: /docs/link-checker/guides/exclude-links
+    title: Exclude Links
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/nuxt-seo/guides/disabling-modules
+    title: Disabling Modules
 ---
 
 Exclude pages from link checking using the `excludePages` option. When a page matches, none of its links will be inspected.
@@ -9,7 +16,7 @@ This is useful when a page renders many external links you don't control or when
 
 ## Usage
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     excludePages: [

--- a/docs/content/2.guides/5.generating-reports.md
+++ b/docs/content/2.guides/5.generating-reports.md
@@ -1,6 +1,13 @@
 ---
 title: Generate Reports
 description: See your link checker results when you build.
+relatedPages:
+  - path: /docs/link-checker/guides/build-scans
+    title: Checking Links on Build
+  - path: /docs/link-checker/api/config
+    title: Config
+  - path: /tools/xml-sitemap-validator
+    title: XML Sitemap Validator
 ---
 
 ## Introduction
@@ -18,7 +25,7 @@ The module supports three report formats: `html`, `markdown` and `json`.
 
 To generate them, you can provide the `report` option:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   linkChecker: {
     report: {
@@ -38,7 +45,7 @@ The reports will be output in the following paths:
 
 ## Publishing Public Reports
 
-Keeping your links healthy can be a lot of effort and be frustrating when you
+Keeping your links healthy can be a lot of effort and be frustrating when
 you are blocked in your CI pipeline due to them.
 
 For this reason, you may want to publish your link checker reports as

--- a/docs/content/2.guides/6.eslint.md
+++ b/docs/content/2.guides/6.eslint.md
@@ -89,15 +89,11 @@ Icon
 </a>
 ```
 
-### ESLint inline disable
+**ESLint inline disable:** Use standard ESLint disable comments (`eslint-disable-next-line`) to skip individual lines in Vue templates or scripts.
 
-Use standard ESLint disable comments (`eslint-disable-next-line`) to skip individual lines in Vue templates or scripts.
-
-## Setup with @nuxt/eslint
+## Setup
 
 If you're using `@nuxt/eslint`, Nuxt Link Checker automatically registers both rules. Zero-config.
-
-## Manual Setup
 
 For projects not using `@nuxt/eslint`, import the plugin in your ESLint flat config:
 
@@ -130,11 +126,9 @@ export default [
 ]
 ```
 
-## Prerequisites
+## How Route Data Gets Generated
 
 The rules read route data from `.nuxt/link-checker/routes.json`, which `nuxt dev` or `nuxt prepare` generates. Make sure to run one of these before linting.
-
-## How Route Data Gets Generated
 
 Nuxt Link Checker collects route data in two phases:
 

--- a/docs/content/2.guides/6.eslint.md
+++ b/docs/content/2.guides/6.eslint.md
@@ -1,6 +1,13 @@
 ---
 title: ESLint Integration
 description: Validate links in your editor with ESLint rules that check against your app's routes and sitemap.
+relatedPages:
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/link-checker/api/config
+    title: Config
+  - path: /docs/nuxt-seo/guides/using-the-modules
+    title: Using the Modules
 ---
 
 Get instant feedback on broken links directly in your editor. The [ESLint](https://eslint.org) integration provides two rules that validate relative URLs against your app's known routes and sitemap data.

--- a/docs/content/4.api/0.config.md
+++ b/docs/content/4.api/0.config.md
@@ -1,6 +1,13 @@
 ---
 title: Config
 description: Configure the link checker module.
+relatedPages:
+  - path: /docs/link-checker/guides/rules
+    title: Inspection Rules
+  - path: /docs/link-checker/guides/exclude-links
+    title: Exclude Links
+  - path: /docs/site-config/api/config
+    title: Site Config API
 ---
 
 ## `enabled`

--- a/docs/content/4.releases/3.v5.md
+++ b/docs/content/4.releases/3.v5.md
@@ -90,4 +90,4 @@ export default [
 ]
 ```
 
-See the [ESLint Integration guide](/guides/eslint) for full details including markdown support, skipping links, and configuration options.
+See the [ESLint Integration guide](/docs/link-checker/guides/eslint) for full details including markdown support, skipping links, and configuration options.

--- a/docs/content/4.releases/4.v4.md
+++ b/docs/content/4.releases/4.v4.md
@@ -1,6 +1,6 @@
 ---
 title: v4.0.0
-description: Release notes for v4.0.0. of Nuxt Link Checker.
+description: Release notes for v4.0.0 of Nuxt Link Checker.
 ---
 
 ## Introduction

--- a/docs/content/4.releases/4.v4.md
+++ b/docs/content/4.releases/4.v4.md
@@ -9,9 +9,7 @@ The v4 major of Nuxt Link Checker is a simple release to remove deprecations and
 
 ## :icon{name="i-noto-warning"} Breaking Features
 
-### Site Config v3
-
-Nuxt Site Config is a module used internally by Nuxt Link Checker.
+**Site Config v3:** Nuxt Site Config is a module used internally by Nuxt Link Checker.
 
 The major update to v3.0.0 shouldn't have any direct effect on your site, however, you may want to double-check
 the [breaking changes](https://github.com/harlan-zw/nuxt-site-config/releases/tag/v3.0.0).

--- a/docs/content/4.releases/5.v3.md
+++ b/docs/content/4.releases/5.v3.md
@@ -1,6 +1,6 @@
 ---
 title: v3.0.0
-description: Release notes for v3.0.0. of Nuxt Link Checker.
+description: Release notes for v3.0.0 of Nuxt Link Checker.
 ---
 
 This new stable release for Nuxt Link Checker introduces many stability improvements as well as a refreshed DevTools experience.

--- a/docs/content/4.releases/6.v2.md
+++ b/docs/content/4.releases/6.v2.md
@@ -43,7 +43,7 @@ Configure these with [site config](/docs/site-config/guides/how-it-works).
 
 ## ⚠️ Breaking Changes
 
-### Config Changes
+**Config Changes:**
 
 - `exclude` renamed to `excludeLinks`
 - `failOn404` renamed to `failOnError`

--- a/docs/content/4.releases/6.v2.md
+++ b/docs/content/4.releases/6.v2.md
@@ -1,6 +1,6 @@
 ---
 title: v2.0.0
-description: Release notes for v2.0.0. of Nuxt Link Checker.
+description: Release notes for v2.0.0 of Nuxt Link Checker.
 ---
 
 ## Features :rocket:


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation

### 📚 Description

Docs-only sweep, part of a content audit across all Nuxt SEO module docs. Everything is under `docs/content/**`.

No factual errors found in this module's docs (rule descriptions and SEO claims checked against current Google guidance); this is a mechanical and consistency pass.

- Troubleshooting conformed to the shared archetype ("Common Issues" renamed to "Debugging", Debugging Tools moved after Submitting an Issue).
- Guides renumbered off a duplicate `2.` prefix. URLs unchanged.
- Added `relatedPages` frontmatter to the 11 non-release pages that lacked it, links validated against the live sitemap.
- Introduction gained a tool CTA callout matching the other module intros; grammar and US-spelling pass.
