### PR TITLE
chore: code cleanup sweep

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@nuxt/kit": "catalog:",
     "@vueuse/core": "catalog:",
     "consola": "catalog:",
+    "defu": "catalog:",
     "diff": "catalog:",
     "fuse.js": "catalog:",
     "h3": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ catalogs:
     consola:
       specifier: ^3.4.2
       version: 3.4.2
+    defu:
+      specifier: ^6.1.7
+      version: 6.1.7
     diff:
       specifier: ^9.0.0
       version: 9.0.0
@@ -146,6 +149,9 @@ importers:
       consola:
         specifier: 'catalog:'
         version: 3.4.2
+      defu:
+        specifier: 'catalog:'
+        version: 6.1.7
       diff:
         specifier: 'catalog:'
         version: 9.0.0
@@ -6787,11 +6793,6 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
-  srvx@0.11.16:
-    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
@@ -6963,10 +6964,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyclip@0.1.14:
-    resolution: {integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==}
-    engines: {node: ^16.14.0 || >= 17.3.0}
 
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
@@ -10660,7 +10657,7 @@ snapshots:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      semver: 7.8.4
+      semver: 7.8.5
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10719,7 +10716,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -10734,7 +10731,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -11177,7 +11174,7 @@ snapshots:
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
+      unplugin-utils: 0.3.2
     optionalDependencies:
       vue: 3.5.40(typescript@6.0.3)
 
@@ -11646,7 +11643,7 @@ snapshots:
       confbox: 0.2.4
       defu: 6.1.7
       dotenv: 17.4.2
-      exsolve: 1.0.8
+      exsolve: 1.1.0
       giget: 3.3.0
       jiti: 2.7.0
       ohash: 2.0.11
@@ -13002,14 +12999,14 @@ snapshots:
   h3@2.0.1-rc.20(crossws@0.4.6(srvx@0.11.22)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.16
+      srvx: 0.11.22
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.22)
 
   h3@2.0.1-rc.22(crossws@0.4.6(srvx@0.11.22)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.16
+      srvx: 0.11.22
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.22)
 
@@ -13508,7 +13505,7 @@ snapshots:
       node-forge: 1.4.0
       pathe: 2.0.3
       std-env: 4.2.0
-      tinyclip: 0.1.14
+      tinyclip: 0.1.15
       ufo: 1.6.4
       untun: 0.1.3
       uqr: 0.1.3
@@ -15829,8 +15826,6 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  srvx@0.11.16: {}
-
   srvx@0.11.22: {}
 
   stable-hash-x@0.2.0: {}
@@ -16016,8 +16011,6 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
-
-  tinyclip@0.1.14: {}
 
   tinyclip@0.1.15: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalog:
   better-sqlite3: ^12.11.1
   bumpp: ^11.1.0
   consola: ^3.4.2
+  defu: ^6.1.7
   diff: ^9.0.0
   eslint: ^10.7.0
   eslint-plugin-harlanzw: ^0.17.0

--- a/src/build/report.ts
+++ b/src/build/report.ts
@@ -9,6 +9,7 @@ import { colors } from 'consola/utils'
 import { useSiteConfig } from 'nuxt-site-config/kit'
 import { relative, resolve } from 'pathe'
 import { htmlTemplate } from './template'
+import { truncateString } from './util'
 
 export interface PathReport {
   route: string
@@ -405,13 +406,6 @@ function createAnchor(text: string): string {
     .replace(nonWordRe, '')
     .replace(whitespaceRe, '-')
     .replace(multiDashRe, '-')
-}
-
-// Helper function to truncate long strings
-function truncateString(str: string, maxLength: number): string {
-  if (str.length <= maxLength)
-    return str
-  return `${str.substring(0, maxLength - 3)}...`
 }
 
 async function generateJsonReport(reports: PathReport[], { storage, storageFilepath }: InspectionContext): Promise<string> {

--- a/src/build/util.ts
+++ b/src/build/util.ts
@@ -1,3 +1,10 @@
+export function truncateString(str: string, maxLength: number): string {
+  if (str.length <= maxLength) {
+    return str
+  }
+  return `${str.substring(0, maxLength - 3)}...`
+}
+
 export async function runParallel<T>(
   inputs: Set<T>,
   cb: (input: T) => unknown | Promise<unknown>,

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,6 +4,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import {
   addPlugin,
   addServerHandler,
+  addServerTemplate,
   createResolver,
   defineNuxtModule,
   hasNuxtModule,
@@ -227,11 +228,9 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.hooks.hook('pages:resolved', (resolved) => {
         pages.unshift(...resolved)
       })
-      nuxt.hooks.hook('nitro:config', (nitroConfig) => {
-        // @ts-expect-error runtime types
-        nitroConfig.virtual['#nuxt-link-checker-sitemap/pages.mjs'] = async () => {
-          return `export default ${JSON.stringify(convertNuxtPagesToPaths(pages), null, 2)}`
-        }
+      addServerTemplate({
+        filename: '#nuxt-link-checker-sitemap/pages.mjs',
+        getContents: async () => `export default ${JSON.stringify(convertNuxtPagesToPaths(pages), null, 2)}`,
       })
       nuxt.options.nitro.alias = nuxt.options.nitro.alias || {}
       const contentVersion = await resolveNuxtContentVersion()

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -5,7 +5,7 @@ import type { ExtractedPayload, InspectionContext, PathReport } from './build/re
 import type { ModuleOptions } from './module'
 import type { LinkInspectionResult } from './runtime/types'
 import { existsSync } from 'node:fs'
-import { useNuxt, useRuntimeConfig } from '@nuxt/kit'
+import { extendRouteRules, useNuxt, useRuntimeConfig } from '@nuxt/kit'
 import { colors } from 'consola/utils'
 import Fuse from 'fuse.js'
 import { useSiteConfig } from 'nuxt-site-config/kit'
@@ -16,7 +16,7 @@ import { ELEMENT_NODE, parse, walkSync } from 'ultrahtml'
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
 import { generateReports } from './build/report'
-import { runParallel } from './build/util'
+import { runParallel, truncateString } from './build/util'
 import { getLinkResponse, getResolvedLinkResponses, setLinkResponse } from './runtime/shared/crawl'
 import { inspect } from './runtime/shared/inspect'
 import { createFilter } from './runtime/shared/sharedUtils'
@@ -101,12 +101,11 @@ function getTextContent(node: any): string {
 export function prerender(config: ModuleOptions, version?: string, routeFileMap: Record<string, string> = {}, nuxt = useNuxt()): void {
   if (config.report?.publish) {
     // make paths non indexable using X-Robots-Tag
-    nuxt.options.nitro.routeRules = nuxt.options.nitro.routeRules || {}
-    nuxt.options.nitro.routeRules['/__link-checker__/*'] = {
+    extendRouteRules('/__link-checker__/*', {
       headers: {
         'X-Robots-Tag': 'noindex',
       },
-    }
+    })
     // Nuxt Robots integration
     // @ts-expect-error untyped
     nuxt.hooks.hook('robots:config', (config) => {
@@ -462,14 +461,4 @@ function groupReportsByLink(reports: any[]): Record<string, { textContent: strin
   })
 
   return result
-}
-
-/**
- * Helper function to truncate long strings
- */
-function truncateString(str: string, maxLength: number): string {
-  if (str.length <= maxLength) {
-    return str
-  }
-  return `${str.substring(0, maxLength - 3)}...`
 }

--- a/src/runtime/app/plugins/view/Main.vue
+++ b/src/runtime/app/plugins/view/Main.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import type { NuxtLinkCheckerClient } from '../../../types'
+import { useEventListener } from '@vueuse/core'
 import { computed, ref } from 'vue'
 import Squiggle from './Squiggle.vue'
-import { useEventListener } from './utils'
 
 const props = defineProps<{
   client: NuxtLinkCheckerClient

--- a/src/runtime/app/plugins/view/utils.ts
+++ b/src/runtime/app/plugins/view/utils.ts
@@ -1,8 +1,0 @@
-import { getCurrentScope, onScopeDispose } from 'vue'
-
-export function useEventListener(target: EventTarget, type: string, listener: any, options?: boolean | AddEventListenerOptions): void {
-  target.addEventListener(type, listener, options)
-  if (getCurrentScope()) {
-    onScopeDispose(() => target.removeEventListener(type, listener, options))
-  }
-}

--- a/src/runtime/shared/inspections/trailing-slash.ts
+++ b/src/runtime/shared/inspections/trailing-slash.ts
@@ -1,5 +1,5 @@
 import type { Rule } from '../../types'
-import { fixSlashes } from 'nuxt-site-config/urls'
+import { fixSlashes, isPathFile } from 'nuxt-site-config/urls'
 import { parseURL } from 'ufo'
 import { defineRule } from './util'
 
@@ -14,9 +14,7 @@ export default function RuleTrailingSlash(): Rule {
         return
       }
 
-      // its a file when the last segment has a dot in it
-      const isFile = $url.pathname.split('/').pop()!.includes('.')
-      if ($url.pathname === '/' || isFile)
+      if ($url.pathname === '/' || isPathFile($url.pathname))
         return
 
       const fix = fixSlashes(siteConfig.trailingSlash, link)


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Small dead-code and duplication sweep over `src/`, no behavior or public API changes.

- Deduped `truncateString`, which existed identically in both `prerender.ts` and `build/report.ts`, into `build/util.ts`.
- Switched `trailing-slash` inspection to `isPathFile` from `nuxt-site-config/urls` instead of a naive "last path segment has a dot" check, matching what `fixSlashes` already uses internally.
- Replaced the hand-rolled `useEventListener` in `Main.vue` with `@vueuse/core`'s (already a dependency), and removed the now-empty `view/utils.ts`.
- Kit 4.5 modernization: swapped a manual `nitro.options.routeRules` write for `extendRouteRules()`, and a manual `nitro:config` hook + `nitroConfig.virtual` write for `addServerTemplate()`.

Verified with `pnpm test:run` (59/59 passing), `pnpm lint`, and `pnpm typecheck` — all clean.