### PR TITLE
fix: use shared Nitro fetch alias

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^5.3.2
       version: 5.3.2
     nuxtseo-shared:
-      specifier: ^5.3.8
-      version: 5.3.8
+      specifier: ^5.3.9
+      version: 5.3.9
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -169,7 +169,7 @@ importers:
         version: 4.1.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vitejs/devtools@0.3.1)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.11.1)(cac@6.7.14)(crossws@0.4.6(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.0)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.139.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.48.0)(typescript@6.0.3)(vite@8.1.5)(vue-tsc@3.3.7(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.139.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5))(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(zod@3.25.76)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.8(e843071bed96792adae7439408339b6b)
+        version: 5.3.9(e843071bed96792adae7439408339b6b)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5765,8 +5765,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.8:
-    resolution: {integrity: sha512-2NOB0I5ikvgChNF5s6OXsxOvNSmluRxaTbS0T1s5EC7X/nzAQXM+OaGYL2D8JffH6HutTayJftJEiFeE+WDbcg==}
+  nuxtseo-shared@5.3.9:
+    resolution: {integrity: sha512-TFp6klJ+K1QJGjfWSP6812ELehdsE0CKPTbbpFT5hV18+GNT76RavnimgJ4xYJlaU8SIbPq9di40JBGORN6wRA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -9745,7 +9745,7 @@ snapshots:
       defu: 6.1.7
       fast-xml-parser: 5.10.1
       nuxt-site-config: 4.1.4(@nuxt/schema@4.5.0)(magic-string@1.0.0)(magicast@0.5.3)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vitejs/devtools@0.3.1)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.11.1)(cac@6.7.14)(crossws@0.4.6(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.0)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.139.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.48.0)(typescript@6.0.3)(vite@8.1.5)(vue-tsc@3.3.7(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.139.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5))(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(zod@3.25.76)
-      nuxtseo-shared: 5.3.8(e843071bed96792adae7439408339b6b)
+      nuxtseo-shared: 5.3.9(e843071bed96792adae7439408339b6b)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -14411,7 +14411,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.4(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.139.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.8(e843071bed96792adae7439408339b6b)
+      nuxtseo-shared: 5.3.9(e843071bed96792adae7439408339b6b)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.4(vue@3.5.40(typescript@6.0.3))
@@ -14695,7 +14695,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.8(e843071bed96792adae7439408339b6b):
+  nuxtseo-shared@5.3.9(e843071bed96792adae7439408339b6b):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magicast@0.5.3)(vite@8.1.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,7 +55,7 @@ catalog:
   nuxt: ^4.5.0
   nuxt-site-config: ^4.1.4
   nuxtseo-layer-devtools: ^5.3.2
-  nuxtseo-shared: ^5.3.8
+  nuxtseo-shared: ^5.3.9
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -193,7 +193,6 @@ export default defineNuxtModule<ModuleOptions>({
     }
     await installNuxtSiteConfig()
     setupNitroRuntimeCompatibility(nuxt)
-    nuxt.options.nitro.alias!.ofetch ||= resolveModule('ofetch', { url: new URL(import.meta.url) })
 
     // Resolve i18n locale codes so we can expand compacted `/:locale(en|fr)/...` routes
     // (nuxt-i18n-micro / @nuxtjs/i18n experimental compactRoutes) into per-locale paths.


### PR DESCRIPTION
## Summary

Use `nuxtseo-shared@5.3.9` as the single owner of Nitro 3 fetch compatibility.

This removes the module-level global `ofetch` alias while keeping the direct dependency used by link checker runtime code.

## Verification

- module build
- packed Nuxt 5 fixture
- ESLint on changed source
