### PR TITLE
chore: adopt shared eslint base config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,26 +2,6 @@ import antfu from '@antfu/eslint-config'
 import harlanzw from 'eslint-plugin-harlanzw'
 
 export default antfu(
-  {
-    type: 'lib',
-    ignores: [
-      'CLAUDE.md',
-      'test/fixtures/**',
-      'playground/**',
-      '.claude/**',
-    ],
-    rules: {
-      'node/prefer-global/process': 'off',
-      'node/prefer-global/buffer': 'off',
-    },
-  },
-  ...harlanzw({ link: true, nuxt: true, vue: true }),
-  {
-    files: ['examples/**/package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-      'pnpm/json-valid-catalog': 'off',
-      'pnpm/json-prefer-workspace-settings': 'off',
-    },
-  },
+  { type: 'lib', vue: true },
+  ...harlanzw({ base: true, link: true, nuxt: true, vue: true }),
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.7.0
       version: 10.7.0
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.2
+      version: 0.19.2
     execa:
       specifier: ^10.0.0
       version: 10.0.0
@@ -233,7 +233,7 @@ importers:
         version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.2(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.0
@@ -4298,8 +4298,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.2:
+    resolution: {integrity: sha512-aXVG5dupBlq2Nn94ffBcxw6iSK7OoFoPriWQW2RlE2FHP8PiQt2hfOU1AxuYk0GqgNMIL9c3cKwdhw1RgyeRcw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -12495,7 +12495,7 @@ snapshots:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.2(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.7.0
       version: 10.7.0
     eslint-plugin-harlanzw:
-      specifier: ^0.18.1
-      version: 0.18.1
+      specifier: ^0.19.0
+      version: 0.19.0
     execa:
       specifier: ^10.0.0
       version: 10.0.0
@@ -233,7 +233,7 @@ importers:
         version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.0
@@ -4298,8 +4298,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.18.1:
-    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -12495,7 +12495,7 @@ snapshots:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.18.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.7.0
       version: 10.7.0
     eslint-plugin-harlanzw:
-      specifier: ^0.17.0
-      version: 0.17.0
+      specifier: ^0.18.1
+      version: 0.18.1
     execa:
       specifier: ^10.0.0
       version: 10.0.0
@@ -233,7 +233,7 @@ importers:
         version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.0
@@ -4298,8 +4298,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.0:
-    resolution: {integrity: sha512-XkG+lnWDSKuUCs5glgqqq8PustfM9sQ9/htmVAGbUxY9Oq22Z2xSXtnZIpbij8loZs1cmXTUzfZ3igwtNEi+ZQ==}
+  eslint-plugin-harlanzw@0.18.1:
+    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -8747,7 +8747,7 @@ snapshots:
       consola: 3.4.2
       debug: 4.4.3(supports-color@10.2.2)
       defu: 6.1.7
-      exsolve: 1.1.0
+      exsolve: 1.1.1
       fuse.js: 7.5.0
       fzf: 0.5.2
       giget: 3.3.0
@@ -11818,7 +11818,7 @@ snapshots:
       confbox: 0.2.4
       defu: 6.1.7
       dotenv: 17.4.2
-      exsolve: 1.1.0
+      exsolve: 1.1.1
       giget: 3.3.0
       jiti: 2.7.0
       ohash: 2.0.11
@@ -12495,7 +12495,7 @@ snapshots:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
+  - eslint-plugin-harlanzw@0.18.1
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -47,7 +48,7 @@ catalog:
   defu: ^6.1.7
   diff: ^9.0.0
   eslint: ^10.7.0
-  eslint-plugin-harlanzw: ^0.17.0
+  eslint-plugin-harlanzw: ^0.18.1
   execa: ^10.0.0
   fuse.js: ^7.5.0
   h3: ^1.15.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.2
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -48,7 +48,7 @@ catalog:
   defu: ^6.1.7
   diff: ^9.0.0
   eslint: ^10.7.0
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.2
   execa: ^10.0.0
   fuse.js: ^7.5.0
   h3: ^1.15.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
-  - eslint-plugin-harlanzw@0.18.1
+  - eslint-plugin-harlanzw@0.19.0
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -48,7 +48,7 @@ catalog:
   defu: ^6.1.7
   diff: ^9.0.0
   eslint: ^10.7.0
-  eslint-plugin-harlanzw: ^0.18.1
+  eslint-plugin-harlanzw: ^0.19.0
   execa: ^10.0.0
   fuse.js: ^7.5.0
   h3: ^1.15.11

--- a/src/module.ts
+++ b/src/module.ts
@@ -306,7 +306,12 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.hooks.hook('listen', (_server, listener) => {
         const baseURL = `http://localhost:${listener.port}`
         const enrichRoutes = async (): Promise<void> => {
-          const debug = await $fetch<{ globalSources: { urls: { loc: string }[] }[] }>(`${baseURL}/__sitemap__/debug.json`).catch(() => null)
+          const debug = await $fetch<{ globalSources: { urls: { loc: string }[] }[] }>(`${baseURL}/__sitemap__/debug.json`)
+            .catch(() => {
+              // sitemap enrichment is best effort: the debug endpoint is missing on older
+              // @nuxtjs/sitemap versions, and route checking works fine without it
+              return null
+            })
           if (!debug)
             return
           const baseOrigin = new URL(baseURL).origin


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Same override blocks were copy-pasted into every one of my repos and had drifted. `eslint-plugin-harlanzw` 0.19.2 ships them as `base()`, so the whole config collapses to:

```js
export default antfu(
  { type: 'lib', vue: true },
  ...harlanzw({ base: true, link: true, nuxt: true, vue: true }),
)
```

26 lines to 7. Nothing in here was actually specific to this repo.

Catalog bump is `eslint-plugin-harlanzw` only, `^0.17.0` to `^0.19.2`. `eslint` stays at `^10.7.0` and `@antfu/eslint-config` at `^9.1.0`; the plugin's peer range is `>=9.0.0` so neither needed to move. Those are a separate change.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I diffed `eslint --print-config` for a src file, a test file and a `.vue` file, plus `eslint . -f json`, before and after. Linted file set is unchanged at 147. Resolved-severity changes, all of them intended:

- `ts/explicit-function-return-type` and `ts/no-use-before-define` off, which is what `base()` normalises for a `type: 'lib'` repo.
- `no-console` and `ts/no-unsafe-function-type` off under test files. This repo never had the test relaxation block that the others did.
- `harlanzw/prefer-satisfies` and `harlanzw/nuxt-no-redundant-component-imports` appear as warnings. New rules across the two-minor jump, zero findings here.

One real finding, worth a look. 0.18.x widened `harlanzw/no-silent-catch` to match `() => null`, not just `() => {}`, and it caught the sitemap enrichment fetch in `src/module.ts`. The swallow is deliberate, the debug endpoint is absent on older `@nuxtjs/sitemap`, so I expanded it to a block with a comment saying so. No behaviour change, but it is the one non-config line in this PR.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



