### PR TITLE
perf: stop pausing 5ms between every link inspection

### DIFF
--- a/src/build/util.ts
+++ b/src/build/util.ts
@@ -5,43 +5,31 @@ export function truncateString(str: string, maxLength: number): string {
   return `${str.substring(0, maxLength - 3)}...`
 }
 
+/**
+ * Run `cb` over every input, with at most `concurrency` callbacks in flight.
+ *
+ * Errors from a callback are logged and do not stop the remaining work.
+ */
 export async function runParallel<T>(
-  inputs: Set<T>,
-  cb: (input: T) => unknown | Promise<unknown>,
-  opts: { concurrency: number, interval?: number },
+  inputs: Iterable<T>,
+  cb: (input: T, index: number) => unknown | Promise<unknown>,
+  opts: { concurrency: number },
 ): Promise<void> {
-  const tasks = new Set<Promise<unknown>>()
-
-  function queueNext(): undefined | Promise<unknown> {
-    const route = inputs.values().next().value
-    if (!route) {
-      return
-    }
-
-    inputs.delete(route)
-    const task = (
-      opts.interval
-        ? new Promise(resolve => setTimeout(resolve, opts.interval))
-        : Promise.resolve()
-    )
-      .then(() => cb(route))
-      .catch((error) => {
-        console.error(error)
-      })
-
-    tasks.add(task)
-    return task.then(() => {
-      tasks.delete(task)
-      if (inputs.size > 0) {
-        return refillQueue()
+  const queue = [...inputs]
+  if (!queue.length) {
+    return
+  }
+  const workerCount = Math.min(Math.max(opts.concurrency, 1), queue.length)
+  let cursor = 0
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (cursor < queue.length) {
+      const index = cursor++
+      try {
+        await cb(queue[index]!, index)
       }
-    })
-  }
-
-  function refillQueue(): Promise<unknown> {
-    const workers = Math.min(opts.concurrency - tasks.size, inputs.size)
-    return Promise.all(Array.from({ length: workers }).fill(queueNext()))
-  }
-
-  await refillQueue()
+      catch (error) {
+        console.error(error)
+      }
+    }
+  }))
 }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -147,8 +147,10 @@ export function prerender(config: ModuleOptions, version?: string, routeFileMap:
       }))
     })
     nitro.hooks.hook('prerender:done', async () => {
-      const payloads = Object.entries(linkMap)
-      if (!payloads?.length)
+      // sort by route: prerendering finishes in a different order on every build, and both the
+      // page search index and the report inherit whatever order we hand them
+      const payloads = Object.entries(linkMap).sort(([a], [b]) => a.localeCompare(b))
+      if (!payloads.length)
         return
 
       const { storage, storageFilepath } = createReportStorage(config, nuxt, nitro)
@@ -237,38 +239,39 @@ async function runInspections(
   let warningCount = 0
   let routeWithIssuesCount = 0
   const totalRoutes = payloads.length
-  const allReports: PathReport[] = []
-
-  // Create a set of inputs for parallel processing
-  const inputs = new Set<[route: string, payload: ExtractedPayload]>(payloads)
+  // keep a slot per route so the report order does not depend on which worker finishes first
+  const reportSlots: (PathReport | undefined)[] = Array.from({ length: totalRoutes })
 
   // Process routes in parallel
   await runParallel<[route: string, payload: ExtractedPayload]>(
-    inputs,
-    async ([route, payload]) => {
-      const reports = await processRouteLinks(route, payload, context)
-
-      // Update counts
-      const routeErrors = reports.filter(r => r.error?.length).length
-      const routeWarnings = reports.filter(r => r.warning?.length).length
-
-      if (routeErrors || routeWarnings) {
-        // Use atomic updates to avoid race conditions
-        errorCount += routeErrors
-        warningCount += routeWarnings
-        routeWithIssuesCount++
-
-        // Only log detailed results if reports are not enabled
-        if (!hasReportsEnabled(config)) {
-          logRouteIssues(route, reports, routeErrors, routeWarnings, nitro, context.routeFileMap)
-        }
-      }
-
-      // Add to reports collection
-      allReports.push({ route, reports } satisfies PathReport)
+    payloads,
+    async ([route, payload], index) => {
+      reportSlots[index] = {
+        route,
+        reports: await processRouteLinks(route, payload, context),
+      } satisfies PathReport
     },
-    { concurrency: 5, interval: 10 }, // Process 5 routes in parallel with small delay between starts
+    { concurrency: 5 }, // Process 5 routes in parallel
   )
+  // a route whose inspection threw leaves an empty slot
+  const allReports = reportSlots.filter(Boolean) as PathReport[]
+
+  // Count and log in route order, so the output is the same on every build
+  for (const { route, reports } of allReports) {
+    const routeErrors = reports.filter(r => r.error?.length).length
+    const routeWarnings = reports.filter(r => r.warning?.length).length
+    if (!routeErrors && !routeWarnings) {
+      continue
+    }
+    errorCount += routeErrors
+    warningCount += routeWarnings
+    routeWithIssuesCount++
+
+    // Only log detailed results if reports are not enabled
+    if (!hasReportsEnabled(config)) {
+      logRouteIssues(route, reports, routeErrors, routeWarnings, nitro, context.routeFileMap)
+    }
+  }
 
   // Show summary at the end
   logSummary(
@@ -294,16 +297,14 @@ async function processRouteLinks(
 
   // Process links in parallel but with controlled concurrency
   const links = payload.links || []
-  const allReports: Partial<LinkInspectionResult>[] = []
-
-  // Create a set of inputs for parallel processing
-  const inputs = new Set<ExtractedPayload['links'][number]>(links)
+  // keep a slot per link so the report order does not depend on which worker finishes first
+  const reportSlots: (Partial<LinkInspectionResult> | undefined)[] = Array.from({ length: links.length })
 
   await runParallel<ExtractedPayload['links'][number]>(
-    inputs,
-    async ({ link, textContent }) => {
+    links,
+    async ({ link, textContent }, index) => {
       if (!urlFilter(link) || !link) {
-        allReports.push({ error: [], warning: [], link })
+        reportSlots[index] = { error: [], warning: [], link }
         return
       }
 
@@ -328,12 +329,13 @@ async function processRouteLinks(
       })
 
       // Add to report collection
-      allReports.push(report)
+      reportSlots[index] = report
     },
-    { concurrency: 5, interval: 5 }, // Process 5 links in parallel with small delay
+    { concurrency: 5 }, // Process 5 links in parallel
   )
 
-  return allReports
+  // a link whose inspection threw leaves an empty slot
+  return reportSlots.filter(Boolean) as Partial<LinkInspectionResult>[]
 }
 
 /**

--- a/test/unit/run-parallel.test.ts
+++ b/test/unit/run-parallel.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { runParallel } from '../../src/build/util'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe('runParallel', () => {
+  it('runs up to `concurrency` callbacks at once', async () => {
+    const inputs = Array.from({ length: 20 }, (_, i) => ({ i }))
+    let inFlight = 0
+    let maxInFlight = 0
+
+    await runParallel(inputs, async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await Promise.resolve()
+      inFlight--
+    }, { concurrency: 5 })
+
+    expect(maxInFlight).toBe(5)
+  })
+
+  it('does not wait for a slow input before starting the next one', async () => {
+    const slow = deferred()
+    const seen: number[] = []
+
+    const run = runParallel([0, 1, 2], async (input) => {
+      seen.push(input)
+      if (input === 0) {
+        await slow.promise
+      }
+    }, { concurrency: 3 })
+
+    await Promise.resolve()
+    expect(seen).toEqual([0, 1, 2])
+    slow.resolve()
+    await run
+  })
+
+  it('visits every input once, including falsy ones, with its index', async () => {
+    const inputs = ['', 0, false, null, undefined, 'a']
+    const seen: [unknown, number][] = []
+
+    await runParallel(inputs, (input, index) => {
+      seen.push([input, index])
+    }, { concurrency: 2 })
+
+    expect(seen.sort((a, b) => a[1] - b[1])).toEqual([
+      ['', 0],
+      [0, 1],
+      [false, 2],
+      [null, 3],
+      [undefined, 4],
+      ['a', 5],
+    ])
+  })
+
+  it('keeps going when a callback throws', async () => {
+    const done: number[] = []
+
+    await runParallel([1, 2, 3], async (input) => {
+      if (input === 2) {
+        throw new Error('boom')
+      }
+      done.push(input)
+    }, { concurrency: 1 })
+
+    expect(done).toEqual([1, 3])
+  })
+})


### PR DESCRIPTION
### Description

Prerender link inspection on nuxtseo.com took **7.2s to check 9 pages and find zero problems**. On a 9 page x 130 link fixture I get the same shape, and the fix takes it from **6.1s to 18ms**:

| links inspected | before | after |
| --- | --- | --- |
| 1,170 (9 pages x 130) | 6,104ms | 18ms |
| 2,340 (9 pages x 260) | 12,589ms | 27ms |

Perfectly linear at ~5.2ms per anchor, which is the tell.

`runParallel` never ran anything in parallel:

```js
return Promise.all(Array.from({ length: workers }).fill(queueNext()))
```

`.fill()` takes a value, so `queueNext()` is called once and the same promise gets copied into every slot. One task in flight, always, no matter what `concurrency` says.

Both callers also passed an `interval`, which the queue applied as a `setTimeout` *before* each task instead of as a stagger between starts. Serial plus a 5ms sleep means every anchor on every prerendered page costs 5ms of doing nothing. Excluded links pay it too, since the delay lands before the filter runs. The links themselves are cheap: responses are memoised per URL and `fetchRemoteUrls` is off by default, so there is no network in the default path at all.

So `runParallel` now runs `concurrency` workers off a shared cursor and the interval is gone.

Two things fell out of that:

- Both callers write into a preallocated slot per input instead of pushing on completion, so report order does not depend on which worker wins the race.
- Route order was already unstable before this PR. `payloads` came out in prerender *completion* order, which feeds the Fuse page index, so `/abt` resolved to "did you mean /about?" or "/absolute?" depending on the build. That made `test/e2e/generate.test.ts` flake at **2 in 10 on main**. Sorting payloads by route fixes it: 0 in 12 after.

`test/unit/run-parallel.test.ts` covers the concurrency, the ordering, falsy inputs (the old `if (!route) return` quietly dropped the whole queue on a falsy first item), and errors not aborting the rest. All four go red on the old implementation.

### Additional context

I did not touch the `concurrency: 5` values. 5 routes x 5 links is 25 in flight, which only matters when `fetchRemoteUrls` is on, and each URL is fetched once. If that turns out to be too aggressive against a real site, rate limiting belongs in `crawlFetch`, not in the inspection loop.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).