### PR TITLE
fix: resolve prerender links against site URL

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -310,6 +310,7 @@ async function processRouteLinks(
 
       const response = await getLinkResponse({
         link,
+        baseURL: siteConfig.url,
         timeout: config.fetchTimeout,
         fetchRemoteUrls: config.fetchRemoteUrls,
         isInStorage() {

--- a/test/e2e/prerender-relative-links.test.ts
+++ b/test/e2e/prerender-relative-links.test.ts
@@ -1,0 +1,45 @@
+import type { AddressInfo } from 'node:net'
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { buildNuxt, createResolver, loadNuxt } from '@nuxt/kit'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
+
+describe('prerender relative links', () => {
+  it('checks a skipped route against the site URL', async () => {
+    const requests: { method?: string, url?: string }[] = []
+    const server = createServer((request, response) => {
+      requests.push({ method: request.method, url: request.url })
+      response.statusCode = request.url === '/live-only' ? 200 : 404
+      response.end()
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    onTestFinished(() => new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    }))
+
+    const { port } = server.address() as AddressInfo
+    vi.stubEnv('NUXT_PUBLIC_SITE_URL', `http://127.0.0.1:${port}`)
+
+    const { resolve } = createResolver(import.meta.url)
+    const rootDir = resolve('../fixtures/prerender-relative-links')
+    const nuxt = await loadNuxt({
+      rootDir,
+      overrides: {
+        nitro: { preset: 'static' },
+        _generate: true,
+      },
+    })
+    await buildNuxt(nuxt)
+
+    const report = JSON.parse(await readFile(
+      resolve(rootDir, '.output/public/__link-checker__/link-checker-report.json'),
+      'utf8',
+    ))
+
+    expect(report).toEqual([])
+    expect(requests).toContainEqual({ method: 'HEAD', url: '/live-only' })
+  })
+})

--- a/test/fixtures/prerender-relative-links/nuxt.config.ts
+++ b/test/fixtures/prerender-relative-links/nuxt.config.ts
@@ -1,0 +1,31 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: [
+    '../../../src/module',
+  ],
+
+  site: {
+    url: process.env.NUXT_PUBLIC_SITE_URL,
+  },
+
+  routeRules: {
+    '/live-only': { prerender: false },
+  },
+
+  nitro: {
+    prerender: {
+      routes: ['/'],
+      crawlLinks: true,
+    },
+  },
+
+  linkChecker: {
+    report: {
+      json: true,
+      publish: true,
+    },
+  },
+
+  compatibilityDate: '2025-01-20',
+})

--- a/test/fixtures/prerender-relative-links/pages/index.vue
+++ b/test/fixtures/prerender-relative-links/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <a href="/live-only">Live page</a>
+</template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### 🔗 Linked issue

Resolves #105

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Prerender inspections treated valid root-relative links as 404 when Nitro skipped their routes. The link checker now resolves those links against the configured site URL.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).